### PR TITLE
variable analysis fix

### DIFF
--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
@@ -1887,7 +1887,7 @@ namespace Pchp.CodeAnalysis.CodeGen
         }
 
         /// <summary>
-        /// Emits <c>PhpString.Append</c> expecting <c>PhpString</c> and <paramref name="t"/> on top of evaluation stack.
+        /// Emits <c>PhpString.Append</c> expecting <c>PhpString</c> and <paramref name="ytype"/> on top of evaluation stack.
         /// </summary>
         /// <param name="ytype">Type of argument loaded on stack.</param>
         internal void Emit_PhpString_Append(TypeSymbol ytype)

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/FlowState.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/FlowState.cs
@@ -215,7 +215,14 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
         public TypeRefMask GetLocalType(VariableHandle handle)
         {
             handle.ThrowIfInvalid();
-            return (handle < _varsType.Length) ? _varsType[handle] : 0;
+            return (handle < _varsType.Length) ? _varsType[handle] : GetUnknownLocalType(handle);
+        }
+
+        TypeRefMask GetUnknownLocalType(VariableHandle handle)
+        {
+            return IsLocalSet(handle)
+                ? TypeRefMask.AnyType.WithRefFlag   // <= SetAllUnknown() called
+                : 0;                                // variable was not initialized in the state yet
         }
 
         /// <summary>


### PR DESCRIPTION
when a variable is defined indirectly (eval include, $$x=..) before it
is used within routine, analysis incorrectly assumed that the variable
is undefined