### PR TITLE
callback with caller context

### DIFF
--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Convert.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Convert.cs
@@ -858,7 +858,8 @@ namespace Pchp.CodeAnalysis.CodeGen
             {
                 if (from.SpecialType == SpecialType.System_String)
                 {
-                    EmitCall(ILOpCode.Call, CoreMethods.Operators.AsCallable_String);
+                    EmitLoadToken(this.CallerType, null);
+                    EmitCall(ILOpCode.Call, CoreMethods.Operators.AsCallable_String_RuntimeTypeHandle);
                 }
                 else if (
                     from.SpecialType == SpecialType.System_Int64 ||
@@ -870,7 +871,8 @@ namespace Pchp.CodeAnalysis.CodeGen
                 else
                 {
                     EmitConvertToPhpValue(from, fromHint);
-                    EmitCall(ILOpCode.Call, CoreMethods.Operators.AsCallable_PhpValue);
+                    EmitLoadToken(this.CallerType, null);
+                    EmitCall(ILOpCode.Call, CoreMethods.Operators.AsCallable_PhpValue_RuntimeTypeHandle);
                 }
             }
         }

--- a/src/Peachpie.CodeAnalysis/Symbols/CoreMembers.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/CoreMembers.cs
@@ -419,8 +419,8 @@ namespace Pchp.CodeAnalysis.Symbols
                 ToPhpString_PhpValue_Context = ct.Convert.Method("ToPhpString", ct.PhpValue, ct.Context);
                 ToClass_PhpValue = ct.Convert.Method("ToClass", ct.PhpValue);
                 ToClass_IPhpArray = ct.Convert.Method("ToClass", ct.IPhpArray);
-                AsCallable_PhpValue = ct.Convert.Method("AsCallable", ct.PhpValue);
-                AsCallable_String = ct.Convert.Method("AsCallable", ct.String);
+                AsCallable_PhpValue_RuntimeTypeHandle = ct.Convert.Method("AsCallable", ct.PhpValue, ct.RuntimeTypeHandle);
+                AsCallable_String_RuntimeTypeHandle = ct.Convert.Method("AsCallable", ct.String, ct.RuntimeTypeHandle);
                 IsInstanceOf_Object_PhpTypeInfo = ct.Convert.Method("IsInstanceOf", ct.Object, ct.PhpTypeInfo);
                 ToIntStringKey_PhpValue = ct.Convert.Method("ToIntStringKey", ct.PhpValue);
 
@@ -504,7 +504,7 @@ namespace Pchp.CodeAnalysis.Symbols
                 ToBoolean_String, ToBoolean_PhpValue, ToBoolean_Object, ToBoolean_IPhpConvertible,
                 ToLong_PhpValue, ToDouble_PhpValue, ToLong_String, ToDouble_String,
                 ToNumber_PhpValue, ToNumber_String,
-                AsObject_PhpValue, AsArray_PhpValue, ToArray_PhpValue, ToPhpString_PhpValue_Context, ToClass_PhpValue, ToClass_IPhpArray, AsCallable_PhpValue, AsCallable_String,
+                AsObject_PhpValue, AsArray_PhpValue, ToArray_PhpValue, ToPhpString_PhpValue_Context, ToClass_PhpValue, ToClass_IPhpArray, AsCallable_PhpValue_RuntimeTypeHandle, AsCallable_String_RuntimeTypeHandle,
                 IsInstanceOf_Object_PhpTypeInfo,
                 ToIntStringKey_PhpValue,
                 Echo_Object, Echo_String, Echo_PhpString, Echo_PhpNumber, Echo_PhpValue, Echo_Double, Echo_Long, Echo_Int32, Echo_Bool,

--- a/src/Peachpie.Library/Arrays.cs
+++ b/src/Peachpie.Library/Arrays.cs
@@ -1663,13 +1663,13 @@ namespace Pchp.Library
             }
 
             // the first callback:
-            cmp1 = vars[vars.Length - comparerCount].AsCallable();
+            cmp1 = vars[vars.Length - comparerCount].AsCallable(default(RuntimeTypeHandle));
             if (PhpVariable.IsValidCallback(cmp1)) return false;
 
             // the second callback:
             if (comparerCount > 1)
             {
-                cmp2 = vars[vars.Length - 1].AsCallable();
+                cmp2 = vars[vars.Length - 1].AsCallable(default(RuntimeTypeHandle));
                 if (!PhpVariable.IsValidCallback(cmp2)) return false;
             }
 

--- a/src/Peachpie.Library/Options.cs
+++ b/src/Peachpie.Library/Options.cs
@@ -472,7 +472,7 @@ namespace Pchp.Library
 
             if (action == IniAction.Set)
             {
-                option = newValue.AsCallable();
+                option = newValue.AsCallable(default(RuntimeTypeHandle));
             }
 
             return oldValue;

--- a/src/Peachpie.Library/Variables.cs
+++ b/src/Peachpie.Library/Variables.cs
@@ -493,15 +493,16 @@ namespace Pchp.Library
         /// method) is also verified.</param>
         /// <returns><B>true</B> if <paramref name="variable"/> denotes a function, <B>false</B>
         /// otherwise.</returns>
-        public static bool is_callable(PhpValue variable, bool syntaxOnly = false)
+        public static bool is_callable(IPhpCallable variable, bool syntaxOnly = false)
         {
-            return PhpVariable.IsValidCallback(variable.AsCallable());  // TODO: check syntaxOnly || can be bound
+            return PhpVariable.IsValidCallback(variable);  // TODO: check syntaxOnly || can be bound
         }
 
         /// <summary>
         /// Verifies that the contents of a variable can be called as a function.
         /// </summary>
         /// <param name="ctx">Current runtime context.</param>
+        /// <param name="callerCtx">Type of the current calling context.</param>
         /// <param name="variable">The variable.</param>
         /// <param name="syntaxOnly">If <B>true</B>, it is only checked that has <pararef name="variable"/>
         /// a valid structure to be used as a callback. if <B>false</B>, the existence of the function (or
@@ -510,9 +511,9 @@ namespace Pchp.Library
         /// <c>SomeClass::SomeMethod</c>).</param>
         /// <returns><B>true</B> if <paramref name="variable"/> denotes a function, <B>false</B>
         /// otherwise.</returns>
-        public static bool is_callable(Context ctx /*, caller*/, PhpValue variable, bool syntaxOnly, out string callableName)
+        public static bool is_callable(Context ctx, [ImportCallerClass] RuntimeTypeHandle callerCtx, PhpValue variable, bool syntaxOnly, out string callableName)
         {
-            var callback = variable.AsCallable();
+            var callback = variable.AsCallable(callerCtx);
             if (PhpVariable.IsValidCallback(callback))
             {
                 callableName = callback.ToString();

--- a/src/Peachpie.Library/Xml.cs
+++ b/src/Peachpie.Library/Xml.cs
@@ -197,12 +197,12 @@ namespace Pchp.Library
                     var name = value.ToStringOrNull();
                     if (name != null)
                     {
-                        return PhpCallback.Create(this.HandlerObject, name);
+                        return PhpCallback.Create(this.HandlerObject, name, default(RuntimeTypeHandle));
                     }
                 }
 
                 // default PHP callback:
-                return value.AsCallable();
+                return value.AsCallable(default(RuntimeTypeHandle));
             }
 
             #endregion

--- a/src/Peachpie.Runtime/Context.Api.cs
+++ b/src/Peachpie.Runtime/Context.Api.cs
@@ -22,7 +22,7 @@ namespace Pchp.Core
         /// <param name="function">Function name valid within current runtime context.</param>
         /// <param name="arguments">Arguments to be passed to the function call.</param>
         /// <returns>Returns value given from the function call.</returns>
-        public PhpValue Call(string function, params PhpValue[] arguments) => PhpCallback.Create(function).Invoke(this, arguments);
+        public PhpValue Call(string function, params PhpValue[] arguments) => PhpCallback.Create(function, default(RuntimeTypeHandle)).Invoke(this, arguments);
 
         /// <summary>
         /// Call a function by its name dynamically.
@@ -30,7 +30,7 @@ namespace Pchp.Core
         /// <param name="function">Function name valid within current runtime context.</param>
         /// <param name="arguments">Arguments to be passed to the function call.</param>
         /// <returns>Returns value given from the function call.</returns>
-        public PhpValue Call(string function, params object[] arguments) => PhpCallback.Create(function).Invoke(this, PhpValue.FromClr(arguments));
+        public PhpValue Call(string function, params object[] arguments) => PhpCallback.Create(function, default(RuntimeTypeHandle)).Invoke(this, PhpValue.FromClr(arguments));
 
         /// <summary>
         /// Creates an instance of a type dynamically with constructor overload resolution.

--- a/src/Peachpie.Runtime/Conversions.cs
+++ b/src/Peachpie.Runtime/Conversions.cs
@@ -289,12 +289,12 @@ namespace Pchp.Core
         /// <summary>
         /// Gets value as a callable object that can be invoked dynamically.
         /// </summary>
-        public static IPhpCallable AsCallable(PhpValue value) => value.AsCallable();
+        public static IPhpCallable AsCallable(PhpValue value, RuntimeTypeHandle callerCtx) => value.AsCallable(callerCtx);
 
         /// <summary>
         /// Creates a callable object from string value.
         /// </summary>
-        public static IPhpCallable AsCallable(string value) => PhpCallback.Create(value);
+        public static IPhpCallable AsCallable(string value, RuntimeTypeHandle callerCtx) => PhpCallback.Create(value, callerCtx);
 
         /// <summary>
         /// Resolves whether given instance <paramref name="obj"/> is of given type <paramref name="tinfo"/>.

--- a/src/Peachpie.Runtime/Dynamic/Cache.cs
+++ b/src/Peachpie.Runtime/Dynamic/Cache.cs
@@ -42,7 +42,7 @@ namespace Pchp.Core.Dynamic
             public static MethodInfo PhpValue_EnsureAlias = typeof(PhpValue).GetMethod("EnsureAlias", Types.Empty);
             public static MethodInfo PhpValue_ToClass = typeof(PhpValue).GetMethod("ToClass", Types.Empty);
             public static MethodInfo PhpValue_ToArray = typeof(PhpValue).GetMethod("ToArray", Types.Empty);
-            public static MethodInfo PhpValue_AsCallable = typeof(PhpValue).GetMethod("AsCallable", Types.Empty);
+            public static MethodInfo PhpValue_AsCallable_RuntimeTypeHandle = typeof(PhpValue).GetMethod("AsCallable", typeof(RuntimeTypeHandle));
             public static MethodInfo PhpValue_AsObject = typeof(PhpValue).GetMethod("AsObject", Types.Empty);
             public static MethodInfo PhpValue_ToString_Context = typeof(PhpValue).GetMethod("ToString", typeof(Context));
             public static MethodInfo PhpValue_ToIntStringKey = typeof(PhpValue).GetMethod("ToIntStringKey");

--- a/src/Peachpie.Runtime/Dynamic/ConvertExpression.cs
+++ b/src/Peachpie.Runtime/Dynamic/ConvertExpression.cs
@@ -327,7 +327,7 @@ namespace Pchp.Core.Dynamic
 
             if (typeof(IPhpCallable).GetTypeInfo().IsAssignableFrom(source.GetTypeInfo())) return expr;
 
-            return Expression.Call(BindToValue(expr), Cache.Operators.PhpValue_AsCallable);
+            return Expression.Call(BindToValue(expr), Cache.Operators.PhpValue_AsCallable_RuntimeTypeHandle, Expression.Default(typeof(RuntimeTypeHandle)));    // TODO: call context instead of default()
         }
 
         private static Expression BindToVoid(Expression expr)

--- a/src/Peachpie.Runtime/PhpValue.TypeTable.cs
+++ b/src/Peachpie.Runtime/PhpValue.TypeTable.cs
@@ -122,7 +122,7 @@ namespace Pchp.Core
             /// </summary>
             /// <param name="me"></param>
             /// <returns>Instance of a callable object, cannot be <c>null</c>, can be invalid.</returns>
-            public virtual IPhpCallable AsCallable(ref PhpValue me) => PhpCallback.CreateInvalid();
+            public virtual IPhpCallable AsCallable(ref PhpValue me, RuntimeTypeHandle callerCtx) => PhpCallback.CreateInvalid();
 
             /// <summary>
             /// Creates a deep copy of PHP variable.
@@ -353,7 +353,7 @@ namespace Pchp.Core
             public override PhpValue GetArrayItem(ref PhpValue me, PhpValue index, bool quiet) => PhpValue.Create(Operators.GetItemValue(me.String, index, quiet));
             public override PhpAlias EnsureItemAlias(ref PhpValue me, PhpValue index, bool quiet) { throw new NotSupportedException(); } // TODO: Err
             public override PhpArray ToArray(ref PhpValue me) => PhpArray.New(me);
-            public override IPhpCallable AsCallable(ref PhpValue me) => PhpCallback.Create(me.String);
+            public override IPhpCallable AsCallable(ref PhpValue me, RuntimeTypeHandle callerCtx) => PhpCallback.Create(me.String, callerCtx);
             public override string DisplayString(ref PhpValue me) => $"'{me.String}'";
             public override void Output(ref PhpValue me, Context ctx) => ctx.Echo(me.String);
             public override void Accept(ref PhpValue me, PhpVariableVisitor visitor) => visitor.Accept(me.String);
@@ -400,7 +400,7 @@ namespace Pchp.Core
             public override PhpAlias EnsureItemAlias(ref PhpValue me, PhpValue index, bool quiet) { throw new NotSupportedException(); } // TODO: Err
             public override PhpValue DeepCopy(ref PhpValue me) => PhpValue.Create(me.WritableString.DeepCopy());
             public override PhpArray ToArray(ref PhpValue me) => PhpArray.New(me.DeepCopy());
-            public override IPhpCallable AsCallable(ref PhpValue me) => PhpCallback.Create(me.WritableString.ToString());
+            public override IPhpCallable AsCallable(ref PhpValue me, RuntimeTypeHandle callerCtx) => PhpCallback.Create(me.WritableString.ToString(), callerCtx);
             public override string DisplayString(ref PhpValue me) => $"'{me.WritableString.ToString()}'";
             public override void Output(ref PhpValue me, Context ctx) => me.WritableString.Output(ctx);
             public override void Accept(ref PhpValue me, PhpVariableVisitor visitor) => visitor.Accept(me.WritableString);
@@ -491,7 +491,7 @@ namespace Pchp.Core
             }
             public override PhpArray ToArray(ref PhpValue me) => Core.Convert.ClassToArray(me.Object);
             public override object AsObject(ref PhpValue me) => me.Object;
-            public override IPhpCallable AsCallable(ref PhpValue me)
+            public override IPhpCallable AsCallable(ref PhpValue me, RuntimeTypeHandle callerCtx)
             {
                 var obj = me.Object;
 
@@ -527,7 +527,7 @@ namespace Pchp.Core
             public override PhpAlias EnsureItemAlias(ref PhpValue me, PhpValue index, bool quiet) => Operators.EnsureItemAlias(me.Array, index, quiet);
             public override PhpValue DeepCopy(ref PhpValue me) => PhpValue.Create(me.Array.DeepCopy());
             public override PhpArray ToArray(ref PhpValue me) => me.Array;
-            public override IPhpCallable AsCallable(ref PhpValue me)
+            public override IPhpCallable AsCallable(ref PhpValue me, RuntimeTypeHandle callerCtx)
             {
                 if (me.Array.Count == 2)
                 {
@@ -540,11 +540,11 @@ namespace Pchp.Core
                     b = e.CurrentValue;
 
                     // [ class => object|string, methodname => string ]
-                    return PhpCallback.Create(a, b);
+                    return PhpCallback.Create(a, b, callerCtx);
                 }
                 else
                 {
-                    return base.AsCallable(ref me);
+                    return base.AsCallable(ref me, callerCtx);
                 }
             }
             public override string DisplayString(ref PhpValue me) => $"array(length = {me.Array.Count})";
@@ -576,7 +576,7 @@ namespace Pchp.Core
             public override PhpAlias EnsureItemAlias(ref PhpValue me, PhpValue index, bool quiet) => me.Alias.Value.EnsureItemAlias(index, quiet);
             public override PhpArray ToArray(ref PhpValue me) => me.Alias.Value.AsArray();
             public override object AsObject(ref PhpValue me) => me.Alias.Value.AsObject();
-            public override IPhpCallable AsCallable(ref PhpValue me) => me.Alias.Value.AsCallable();
+            public override IPhpCallable AsCallable(ref PhpValue me, RuntimeTypeHandle callerCtx) => me.Alias.Value.AsCallable(callerCtx);
             public override string DisplayString(ref PhpValue me) => "&" + me.Alias.Value.DisplayString;
             public override void Output(ref PhpValue me, Context ctx) => me.Alias.Value.Output(ctx);
             public override void Accept(ref PhpValue me, PhpVariableVisitor visitor) => visitor.Accept(me.Alias);

--- a/src/Peachpie.Runtime/PhpValue.TypeTable.cs
+++ b/src/Peachpie.Runtime/PhpValue.TypeTable.cs
@@ -121,6 +121,7 @@ namespace Pchp.Core
             /// Gets callable wrapper for dynamic object invocation.
             /// </summary>
             /// <param name="me"></param>
+            /// <param name="callerCtx">Current caller type.</param>
             /// <returns>Instance of a callable object, cannot be <c>null</c>, can be invalid.</returns>
             public virtual IPhpCallable AsCallable(ref PhpValue me, RuntimeTypeHandle callerCtx) => PhpCallback.CreateInvalid();
 

--- a/src/Peachpie.Runtime/PhpValue.cs
+++ b/src/Peachpie.Runtime/PhpValue.cs
@@ -360,8 +360,7 @@ namespace Pchp.Core
         /// <summary>
         /// Gets callable wrapper for the object dynamic invocation.
         /// </summary>
-        /// <returns></returns>
-        public IPhpCallable AsCallable(RuntimeTypeHandle callerCtx) => _type.AsCallable(ref this, callerCtx);
+        public IPhpCallable AsCallable(RuntimeTypeHandle callerCtx = default(RuntimeTypeHandle)) => _type.AsCallable(ref this, callerCtx);
 
         public object EnsureObject() => _type.EnsureObject(ref this);
 

--- a/src/Peachpie.Runtime/PhpValue.cs
+++ b/src/Peachpie.Runtime/PhpValue.cs
@@ -361,7 +361,7 @@ namespace Pchp.Core
         /// Gets callable wrapper for the object dynamic invocation.
         /// </summary>
         /// <returns></returns>
-        public IPhpCallable AsCallable() => _type.AsCallable(ref this);
+        public IPhpCallable AsCallable(RuntimeTypeHandle callerCtx) => _type.AsCallable(ref this, callerCtx);
 
         public object EnsureObject() => _type.EnsureObject(ref this);
 


### PR DESCRIPTION
- creating PHP callback requires caller context to resolve reserved type names and to resolve methods visibility
- added resolving of reserved type names
- TODO: check methods visibility