### PR TITLE
Types overriding

### DIFF
--- a/src/Peachpie.CodeAnalysis/CodeGen/GhostMethodBuilder.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/GhostMethodBuilder.cs
@@ -19,8 +19,12 @@ namespace Pchp.CodeAnalysis.CodeGen
             TypeSymbol ghostreturn, IEnumerable<ParameterSymbol> ghostparams,
             MethodSymbol explicitOverride = null)
         {
+            string prefix = (explicitOverride != null)
+                ? (explicitOverride.ContainingType.GetFullName() + ".")
+                : null;
+
             var ghost = new SynthesizedMethodSymbol(
-                containingtype, method.Name, method.IsStatic, explicitOverride != null, ghostreturn, method.DeclaredAccessibility)
+                containingtype, prefix + method.Name, method.IsStatic, explicitOverride != null, ghostreturn, method.DeclaredAccessibility)
             {
                 ExplicitOverride = explicitOverride,
             };

--- a/src/Peachpie.CodeAnalysis/CodeGen/GhostMethodBuilder.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/GhostMethodBuilder.cs
@@ -19,8 +19,8 @@ namespace Pchp.CodeAnalysis.CodeGen
             TypeSymbol ghostreturn, IEnumerable<ParameterSymbol> ghostparams,
             MethodSymbol explicitOverride = null)
         {
-            string prefix = (explicitOverride != null)
-                ? (explicitOverride.ContainingType.GetFullName() + ".")
+            string prefix = (explicitOverride != null && explicitOverride.ContainingType.IsInterface)
+                ? (explicitOverride.ContainingType.GetFullName() + ".")   // explicit interface override
                 : null;
 
             var ghost = new SynthesizedMethodSymbol(

--- a/src/Peachpie.CodeAnalysis/CodeGen/Symbols/NamedTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Symbols/NamedTypeSymbol.cs
@@ -107,7 +107,7 @@ namespace Pchp.CodeAnalysis.Symbols
             }
         }
 
-        OverrideInfo[] _overrides;
+        OverrideInfo[] _lazyOverrides;
 
         /// <summary>
         /// Matches all methods that can be overriden (non-static, public or protected, abstract or virtual)
@@ -118,10 +118,10 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <param name="diagnostics"></param>
         internal OverrideInfo[] ResolveOverrides(DiagnosticBag diagnostics)
         {
-            if (_overrides != null)
+            if (_lazyOverrides != null)
             {
                 // already resolved
-                return _overrides;
+                return _lazyOverrides;
             }
 
             // TODO: ignore System.Object ?
@@ -188,7 +188,7 @@ namespace Pchp.CodeAnalysis.Symbols
             }
 
             // cache & return
-            return (_overrides = overrides.ToArray());
+            return (_lazyOverrides = overrides.ToArray());
         }
     }
 }

--- a/src/Peachpie.CodeAnalysis/Symbols/OverrideHelper.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/OverrideHelper.cs
@@ -159,7 +159,7 @@ namespace Pchp.CodeAnalysis.Symbols
 
         public static MethodSymbol ResolveMethodImplementation(MethodSymbol method, NamedTypeSymbol type)
         {
-            while (type != null)
+            for (; type != null; type = type.BaseType)
             {
                 var candidates = type.GetMembers(method.RoutineName).OfType<MethodSymbol>().Where(CanOverride);
                 var resolved = ResolveMethodImplementation(method, candidates);
@@ -167,9 +167,6 @@ namespace Pchp.CodeAnalysis.Symbols
                 {
                     return resolved;
                 }
-
-                //
-                type = type.BaseType;
             }
 
             //

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/MetadataDecoder.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/MetadataDecoder.cs
@@ -351,7 +351,7 @@ namespace Pchp.CodeAnalysis.Symbols
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                 if (scope != targetTypeSymbol &&
                     !(targetTypeSymbol.IsInterfaceType()
-                        ? scope./*AllInterfacesNoUseSiteDiagnostics*/AllInterfaces.Contains((NamedTypeSymbol)targetTypeSymbol)
+                        ? scope.AllInterfaces.Contains((NamedTypeSymbol)targetTypeSymbol)
                         : scope.IsDerivedFrom(targetTypeSymbol, ignoreDynamic: false, useSiteDiagnostics: ref useSiteDiagnostics)))
                 {
                     return null;

--- a/src/Peachpie.CodeAnalysis/Symbols/TypeSymbolExtensions.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/TypeSymbolExtensions.cs
@@ -76,12 +76,22 @@ namespace Pchp.CodeAnalysis.Symbols
         {
             if (oftype != null)
             {
-                HashSet<DiagnosticInfo> set = new HashSet<DiagnosticInfo>();
-                if (t.IsEqualToOrDerivedFrom(oftype, true, ref set))
+                if (t.Equals(oftype, ignoreDynamic: true))
+                {
                     return true;
+                }
 
-                if (oftype.IsInterfaceType() && t.AllInterfaces.Contains(oftype))
-                    return true;
+                if (oftype.IsClassType())
+                {
+                    HashSet<DiagnosticInfo> set = new HashSet<DiagnosticInfo>();
+                    if (t.IsDerivedFrom(oftype, true, ref set))
+                        return true;
+                }
+
+                if (oftype.IsInterfaceType())
+                {
+                    return t.ImplementsInterface(oftype);
+                }
             }
 
             //

--- a/src/Peachpie.CodeAnalysis/Symbols/TypeSymbolExtensions.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/TypeSymbolExtensions.cs
@@ -83,7 +83,7 @@ namespace Pchp.CodeAnalysis.Symbols
 
                 if (oftype.IsClassType())
                 {
-                    HashSet<DiagnosticInfo> set = new HashSet<DiagnosticInfo>();
+                    HashSet<DiagnosticInfo> set = null;
                     if (t.IsDerivedFrom(oftype, true, ref set))
                         return true;
                 }

--- a/src/Peachpie.CodeAnalysis/Utilities/NameUtils.cs
+++ b/src/Peachpie.CodeAnalysis/Utilities/NameUtils.cs
@@ -169,6 +169,14 @@ namespace Pchp.CodeAnalysis
         }
 
         /// <summary>
+        /// Gets full CLR name including the namespace part.
+        /// </summary>
+        public static string GetFullName(this NamedTypeSymbol t)
+        {
+            return Microsoft.CodeAnalysis.MetadataHelpers.BuildQualifiedName(t.NamespaceName, t.MetadataName);
+        }
+
+        /// <summary>
         /// Compares two arrays.
         /// </summary>
         public static bool NamesEquals(this Name[] names1, Name[] names2)

--- a/tests/classes/overloading_004.php
+++ b/tests/classes/overloading_004.php
@@ -1,0 +1,25 @@
+<?php
+ 
+ interface I
+ {
+     public function foo();
+ }
+ 
+ class A implements I
+ {
+     public function foo() {
+         return __METHOD__;
+     }
+ }
+ 
+
+ class B extends A
+ {
+     public function foo() {
+         return __METHOD__;
+     }
+ }
+ 
+ echo (new B)->foo();
+ 
+ echo "Done.";

--- a/tests/classes/overloading_005.php
+++ b/tests/classes/overloading_005.php
@@ -1,0 +1,18 @@
+<?php
+interface I
+{
+    public function foo();
+}
+abstract class A implements I
+{
+    public abstract function foo();
+}
+class B extends A
+{
+    public function foo() {
+        return __METHOD__;
+    }
+}
+echo (new B)->foo();
+
+echo "Done.";


### PR DESCRIPTION
- TypeSymbol API fixes (AllInterfaces)
- cleanup
- explicit ghost overrides with explicit method name
- ghost stup not generated if not needed
- explicit override only for interfaces