### PR TITLE
mutable string implementation

### DIFF
--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Convert.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Convert.cs
@@ -730,7 +730,9 @@ namespace Pchp.CodeAnalysis.CodeGen
             }
             else if (from.SpecialType == SpecialType.System_Void)
             {
-                EmitCall(ILOpCode.Newobj, CoreMethods.Ctors.PhpString);
+                // Template: new PhpString("")
+                _il.EmitStringConstant(string.Empty);
+                EmitCall(ILOpCode.Newobj, CoreMethods.Ctors.PhpString_string);
             }
             else if (from == CoreTypes.PhpValue)
             {

--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Convert.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Convert.cs
@@ -132,11 +132,11 @@ namespace Pchp.CodeAnalysis.CodeGen
                         }
                         break;
                     }
-                    //else if (from == CoreTypes.PhpString)
-                    //{
-                    //    EmitCall(ILOpCode.Call, CoreMethods.PhpString.ToBoolean);
-                    //    break;
-                    //}
+                    else if (from == CoreTypes.PhpString)
+                    {
+                        EmitCall(ILOpCode.Call, CoreMethods.PhpString.ToBoolean);
+                        break;
+                    }
                     //else if (from.IsOfType(CoreTypes.IPhpArray))
                     //{
                     //    // TODO: != null && .Count != 0
@@ -554,7 +554,7 @@ namespace Pchp.CodeAnalysis.CodeGen
 
             if (stack == CoreTypes.PhpString)
             {
-                return EmitCall(ILOpCode.Callvirt, CoreMethods.PhpString.ToNumber)
+                return EmitCall(ILOpCode.Call, CoreMethods.PhpString.ToNumber)
                     .Expect(CoreTypes.PhpNumber);
             }
 
@@ -1263,6 +1263,11 @@ namespace Pchp.CodeAnalysis.CodeGen
                     {
                         EmitConvertToPhpNumber(from, fromHint);
                     }
+                    else if (to == CoreTypes.PhpString)
+                    {
+                        // -> PhpString
+                        EmitConvertToPhpString(from, fromHint);
+                    }
                     else if (to.IsReferenceType)
                     {
                         if (to == CoreTypes.PhpArray || to == CoreTypes.IPhpArray || to == CoreTypes.IPhpEnumerable || to == CoreTypes.PhpHashtable)
@@ -1270,11 +1275,6 @@ namespace Pchp.CodeAnalysis.CodeGen
                             // -> PhpArray
                             // TODO: try unwrap "value.Object as T"
                             EmitConvertToPhpArray(from, fromHint);
-                        }
-                        else if (to == CoreTypes.PhpString)
-                        {
-                            // -> PhpString
-                            EmitConvertToPhpString(from, fromHint);
                         }
                         else
                         {
@@ -1352,7 +1352,6 @@ namespace Pchp.CodeAnalysis.CodeGen
                     }
 
                     if (from.IsReferenceType &&
-                        from != CoreTypes.PhpString &&
                         !from.IsOfType(CoreTypes.PhpResource))
                     {
                         Debug.Assert(from != CoreTypes.PhpAlias);

--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
@@ -1573,6 +1573,11 @@ namespace Pchp.CodeAnalysis.CodeGen
                 _il.EmitDoubleConstant(0.0);    // 0.0
                 _il.EmitBranch(ILOpCode.Blt, lblfalse);
             }
+            else if (stack == CoreTypes.PhpString)
+            {
+                EmitCall(ILOpCode.Call, CoreMethods.PhpString.IsNull_PhpString);    // PhpString.IsDefault
+                _il.EmitBranch(ILOpCode.Brtrue, lblfalse);
+            }
             else if (stack.IsReferenceType)
             {
                 _il.EmitNullConstant(); // null
@@ -1980,10 +1985,10 @@ namespace Pchp.CodeAnalysis.CodeGen
         }
 
         /// <summary>
-        /// Emits <c>PhpString.Append</c> expecting <c>PhpString</c> and <paramref name="ytype"/> on top of evaluation stack.
+        /// Emits <c>PhpString.Blob.Append</c> expecting <c>PhpString.Blob</c> and <paramref name="ytype"/> on top of evaluation stack.
         /// </summary>
         /// <param name="ytype">Type of argument loaded on stack.</param>
-        internal void Emit_PhpString_Append(TypeSymbol ytype)
+        internal void Emit_PhpStringBlob_Append(TypeSymbol ytype)
         {
             if (ytype == CoreTypes.PhpAlias)
             {
@@ -1993,19 +1998,19 @@ namespace Pchp.CodeAnalysis.CodeGen
             if (ytype == CoreTypes.PhpString)
             {
                 // Append(PhpString)
-                EmitCall(ILOpCode.Callvirt, CoreMethods.PhpString.Append_PhpString);
+                EmitCall(ILOpCode.Callvirt, CoreMethods.PhpStringBlob.Add_PhpString);
             }
             else if (ytype == CoreTypes.PhpValue)
             {
                 // Append(PhpValue, Context)
                 EmitLoadContext();
-                EmitCall(ILOpCode.Callvirt, CoreMethods.PhpString.Append_PhpValue_Context);
+                EmitCall(ILOpCode.Callvirt, CoreMethods.PhpStringBlob.Add_PhpValue_Context);
             }
             else
             {
                 // Append(string)
                 EmitConvertToString(ytype, 0);
-                EmitCall(ILOpCode.Callvirt, CoreMethods.PhpString.Append_String);
+                EmitCall(ILOpCode.Callvirt, CoreMethods.PhpStringBlob.Add_String);
             }
         }
 
@@ -2827,7 +2832,9 @@ namespace Pchp.CodeAnalysis.CodeGen
                 }
                 else if (t == CoreTypes.PhpString)
                 {
-                    t = EmitCall(ILOpCode.Callvirt, CoreMethods.PhpString.DeepCopy);
+                    Debug.Assert(t.IsStructType());
+                    // Template: new PhpString( <STACK> )
+                    t = EmitCall(ILOpCode.Newobj, CoreMethods.Ctors.PhpString_PhpString);                    
                 }
                 else if (t == CoreTypes.PhpArray)
                 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundExpression.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundExpression.cs
@@ -3212,7 +3212,7 @@ namespace Pchp.CodeAnalysis.Semantics
             else
             {
                 // CALL EnsureWritable(x) : Blob
-                cg.EmitCall(ILOpCode.Call, cg.CoreMethods.PhpString.EnsureWritable_PhpString); // Blob
+                cg.EmitCall(ILOpCode.Call, cg.CoreMethods.PhpString.AsWritable_PhpString); // Blob
 
                 // <STACK>.Append (Y)
                 cg.Builder.EmitOpCode(ILOpCode.Dup);
@@ -3643,6 +3643,13 @@ namespace Pchp.CodeAnalysis.Semantics
             else if (tArray == cg.CoreTypes.String)
             {
                 // ok
+                safeToUseIntStringKey = true;
+            }
+            else if (tArray == cg.CoreTypes.PhpString)
+            {
+                // <PhpString>.AsArray
+                tArray = cg.EmitCall(ILOpCode.Call, cg.CoreMethods.PhpString.AsArray_PhpString);
+                safeToUseIntStringKey = true;
             }
             else if (tArray == cg.CoreTypes.Void)
             {

--- a/src/Peachpie.CodeAnalysis/CodeGen/Places.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Places.cs
@@ -683,6 +683,13 @@ namespace Pchp.CodeAnalysis.CodeGen
                             .Expect(cg.CoreTypes.IPhpArray);
                     }
                 }
+                else if (type == cg.CoreTypes.PhpString)
+                {
+                    Debug.Assert(type.IsValueType);
+                    // <place>.EnsureWritable() : IPhpArray
+                    _place.EmitLoadAddress(cg.Builder); // LOAD ref PhpString
+                    return cg.EmitCall(ILOpCode.Call, cg.CoreMethods.PhpString.EnsureWritable);
+                }
                 else if (type.IsOfType(cg.CoreTypes.IPhpArray))
                 {
                     // Operators.EnsureArray(ref <place>)
@@ -1540,6 +1547,13 @@ namespace Pchp.CodeAnalysis.CodeGen
                     EmitOpCode_LoadAddress(cg);
                     return cg.EmitCall(ILOpCode.Call, cg.CoreMethods.PhpValue.EnsureArray)
                             .Expect(cg.CoreTypes.IPhpArray);
+                }
+                else if (type == cg.CoreTypes.PhpString)
+                {
+                    Debug.Assert(type.IsValueType);
+                    // <place>.EnsureWritable() : IPhpArray
+                    EmitOpCode_LoadAddress(cg); // LOAD ref PhpString
+                    return cg.EmitCall(ILOpCode.Call, cg.CoreMethods.PhpString.EnsureWritable);
                 }
                 else if (type.IsOfType(cg.CoreTypes.IPhpArray))
                 {

--- a/src/Peachpie.CodeAnalysis/Semantics/ExpressionsExtension.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/ExpressionsExtension.cs
@@ -29,10 +29,10 @@ namespace Pchp.CodeAnalysis.Semantics
             if (value == null)
                 return true;
 
-            if (value is string && ((string)value).Length == 0)
+            if (value is string str && str.Length == 0)
                 return true;
 
-            if (value is bool && ((bool)value) == false)
+            if (value is bool b && b == false)
                 return true;
 
             return false;

--- a/src/Peachpie.CodeAnalysis/Symbols/CoreMembers.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/CoreMembers.cs
@@ -835,14 +835,15 @@ namespace Pchp.CodeAnalysis.Symbols
                 ToBytes_Context = ct.Convert.Method("ToBytes", ct.PhpString, ct.Context);
 
                 EnsureWritable = ct.PhpString.Method("EnsureWritable");
-                EnsureWritable_PhpString = ct.PhpString.Method("EnsureWritable", ct.PhpString);
+                AsWritable_PhpString = ct.PhpString.Method("AsWritable", ct.PhpString);
+                AsArray_PhpString = ct.PhpString.Method("AsArray", ct.PhpString);
 
                 IsNull_PhpString = ct.PhpString.Method("IsNull", ct.PhpString);
             }
 
             public readonly CoreMethod
                 ToLong, ToDouble, ToBoolean, ToString_Context, ToNumber, ToBytes_Context,
-                EnsureWritable, EnsureWritable_PhpString,
+                EnsureWritable, AsWritable_PhpString, AsArray_PhpString,
                 IsNull_PhpString;
         }
 

--- a/src/Peachpie.CodeAnalysis/Symbols/CoreMembers.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/CoreMembers.cs
@@ -351,6 +351,7 @@ namespace Pchp.CodeAnalysis.Symbols
         public readonly PhpNumberHolder PhpNumber;
         public readonly OperatorsHolder Operators;
         public readonly PhpStringHolder PhpString;
+        public readonly PhpStringBlobHolder PhpStringBlob;
         public readonly ConstructorsHolder Ctors;
         public readonly ContextHolder Context;
         public readonly DynamicHolder Dynamic;
@@ -367,6 +368,7 @@ namespace Pchp.CodeAnalysis.Symbols
             IPhpConvertible = new IPhpConvertibleHolder(types);
             PhpNumber = new PhpNumberHolder(types);
             PhpString = new PhpStringHolder(types);
+            PhpStringBlob = new PhpStringBlobHolder(types);
             Operators = new OperatorsHolder(types);
             Ctors = new ConstructorsHolder(types);
             Context = new ContextHolder(types);
@@ -832,17 +834,29 @@ namespace Pchp.CodeAnalysis.Symbols
                 ToNumber = ct.PhpString.Method("ToNumber");
                 ToBytes_Context = ct.PhpString.Method("ToBytes", ct.Context);
 
-                Append_String = ct.PhpString.Method("Append", ct.String);
-                Append_PhpString = ct.PhpString.Method("Append", ct.PhpString);
-                Append_PhpValue_Context = ct.PhpString.Method("Append", ct.PhpValue, ct.Context);
+                EnsureWritable = ct.PhpString.Method("EnsureWritable");
+                EnsureWritable_PhpString = ct.PhpString.Method("EnsureWritable", ct.PhpString);
 
-                DeepCopy = ct.PhpString.Method("DeepCopy");
+                IsNull_PhpString = ct.PhpString.Method("IsNull", ct.PhpString);
             }
 
             public readonly CoreMethod
                 ToLong, ToDouble, ToBoolean, ToString_Context, ToNumber, ToBytes_Context,
-                Append_String, Append_PhpString, Append_PhpValue_Context,
-                DeepCopy;
+                EnsureWritable, EnsureWritable_PhpString,
+                IsNull_PhpString;
+        }
+
+        public struct PhpStringBlobHolder
+        {
+            public PhpStringBlobHolder(CoreTypes ct)
+            {
+                Add_String = ct.PhpString_Blob.Method("Add", ct.String);
+                Add_PhpString = ct.PhpString_Blob.Method("Add", ct.PhpString);
+                Add_PhpValue_Context = ct.PhpString_Blob.Method("Add", ct.PhpValue, ct.Context);
+            }
+
+            public readonly CoreMethod
+                Add_String, Add_PhpString, Add_PhpValue_Context;
         }
 
         public struct IPhpArrayHolder
@@ -937,11 +951,12 @@ namespace Pchp.CodeAnalysis.Symbols
             public ConstructorsHolder(CoreTypes ct)
             {
                 PhpAlias_PhpValue_int = ct.PhpAlias.Ctor(ct.PhpValue, ct.Int32);
-                PhpString = ct.PhpString.Ctor();
+                PhpString_Blob = ct.PhpString.Ctor(ct.PhpString_Blob);
                 PhpString_string = ct.PhpString.Ctor(ct.String);
                 PhpString_string_string = ct.PhpString.Ctor(ct.String, ct.String);
                 PhpString_PhpValue_Context = ct.PhpString.Ctor(ct.PhpValue, ct.Context);
                 PhpString_PhpString = ct.PhpString.Ctor(ct.PhpString);
+                Blob = ct.PhpString_Blob.Ctor();
                 PhpArray = ct.PhpArray.Ctor();
                 PhpArray_int = ct.PhpArray.Ctor(ct.Int32);
                 IntStringKey_int = ct.IntStringKey.Ctor(ct.Int32);
@@ -960,7 +975,8 @@ namespace Pchp.CodeAnalysis.Symbols
             public readonly CoreConstructor
                 PhpAlias_PhpValue_int,
                 PhpArray, PhpArray_int,
-                PhpString, PhpString_string, PhpString_PhpString, PhpString_string_string, PhpString_PhpValue_Context,
+                PhpString_Blob, PhpString_string, PhpString_PhpString, PhpString_string_string, PhpString_PhpValue_Context,
+                Blob,
                 IntStringKey_int, IntStringKey_string,
                 ScriptAttribute_string, PhpTraitAttribute, PhpTypeAttribute_string_string, PhpFieldsOnlyCtorAttribute, NotNullAttribute,
                 ScriptDiedException, ScriptDiedException_Long, ScriptDiedException_PhpValue;

--- a/src/Peachpie.CodeAnalysis/Symbols/CoreMembers.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/CoreMembers.cs
@@ -827,12 +827,12 @@ namespace Pchp.CodeAnalysis.Symbols
         {
             public PhpStringHolder(CoreTypes ct)
             {
-                ToBoolean = ct.PhpString.Method("ToBoolean");
-                ToLong = ct.PhpString.Method("ToLong");
-                ToDouble = ct.PhpString.Method("ToDouble");
-                ToString_Context = ct.PhpString.Method("ToString", ct.Context);
-                ToNumber = ct.PhpString.Method("ToNumber");
-                ToBytes_Context = ct.PhpString.Method("ToBytes", ct.Context);
+                ToBoolean = ct.Convert.Method("ToBoolean", ct.PhpString);
+                ToLong = ct.Convert.Method("ToLong", ct.PhpString);
+                ToDouble = ct.Convert.Method("ToDouble", ct.PhpString);
+                ToString_Context = ct.Convert.Method("ToString", ct.PhpString, ct.Context);
+                ToNumber = ct.Convert.Method("ToNumber", ct.PhpString);
+                ToBytes_Context = ct.Convert.Method("ToBytes", ct.PhpString, ct.Context);
 
                 EnsureWritable = ct.PhpString.Method("EnsureWritable");
                 EnsureWritable_PhpString = ct.PhpString.Method("EnsureWritable", ct.PhpString);

--- a/src/Peachpie.Library.Graphics/Exif.cs
+++ b/src/Peachpie.Library.Graphics/Exif.cs
@@ -306,7 +306,7 @@ namespace Peachpie.Library.Graphics
             if (string.IsNullOrEmpty(filename))
             {
                 PhpException.Throw(PhpError.Warning, Resources.filename_cannot_be_empty);
-                return null;
+                return default(PhpString);
             }
 
             Image<Rgba32> thumbnail = null;
@@ -316,7 +316,7 @@ namespace Peachpie.Library.Graphics
             var bytes = Utils.ReadPhpBytes(ctx, filename);
 
             if (bytes == null)
-                return null;
+                return default(PhpString);
 
             // get thumbnail from <filename>'s content:
             using (var ms = new MemoryStream(bytes))
@@ -331,13 +331,13 @@ namespace Peachpie.Library.Graphics
                 }
                 catch
                 {
-                    return null;
+                    return default(PhpString);
                 }
             }
 
             if (thumbnail == null)
             {
-                return null;
+                return default(PhpString);
             }
 
             //

--- a/src/Peachpie.Library.MySql/MySql.Functions.cs
+++ b/src/Peachpie.Library.MySql/MySql.Functions.cs
@@ -283,7 +283,7 @@ namespace Peachpie.Library.MySql
         public static PhpResource mysql_query(Context ctx, PhpString query, PhpResource link = null)
         {
             var connection = ValidConnection(ctx, link);
-            if (query == null || connection == null || query.IsEmpty)
+            if (connection == null || query.IsEmpty)
             {
                 return null;
             }
@@ -1044,7 +1044,7 @@ namespace Peachpie.Library.MySql
         /// <returns>Escaped string.</returns>
         public static PhpString mysql_escape_string(Context ctx, PhpString unescaped_str)
         {
-            if (unescaped_str == null || unescaped_str.IsEmpty)
+            if (unescaped_str.IsEmpty)
             {
                 return PhpString.Empty;
             }

--- a/src/Peachpie.Library.XmlDom/DOMDocument.cs
+++ b/src/Peachpie.Library.XmlDom/DOMDocument.cs
@@ -712,7 +712,7 @@ namespace Peachpie.Library.XmlDom
                 }
                 else
                 {
-                    return null;
+                    return default(PhpString);
                 }
             }
         }

--- a/src/Peachpie.Library.XmlDom/XsltProcessor.cs
+++ b/src/Peachpie.Library.XmlDom/XsltProcessor.cs
@@ -233,7 +233,7 @@ namespace Peachpie.Library.XmlDom
             {
                 if (!TransformInternal(doc.XmlNode, stream))
                 {
-                    return null;
+                    return default(PhpString);
                 }
 
                 return new PhpString(stream.ToArray());

--- a/src/Peachpie.Library/BitConverter.cs
+++ b/src/Peachpie.Library/BitConverter.cs
@@ -515,7 +515,7 @@ namespace Pchp.Library
         public static PhpArray unpack(Context ctx, string format, PhpString data)
         {
             if (format == null) return null;
-            byte[] buffer = (data != null) ? data.ToBytes(ctx) : ArrayUtils.EmptyBytes;
+            byte[] buffer = data.ToBytes(ctx);
 
             var encoding = ctx.StringEncoding;
             byte[] reversed = new byte[4]; // used for reversing the order of bytes in buffer

--- a/src/Peachpie.Library/FileSystem.cs
+++ b/src/Peachpie.Library/FileSystem.cs
@@ -588,7 +588,7 @@ namespace Pchp.Library
             var stream = PhpStream.GetValid(handle);
             if (stream == null)
             {
-                return null;
+                return default(PhpString);
             }
 
             return stream.IsText
@@ -606,7 +606,7 @@ namespace Pchp.Library
         [return: CastToFalse]
         public static PhpString fgetc(Context ctx, PhpResource handle)
         {
-            return feof(handle) ? null : fread(ctx, handle, 1);
+            return feof(handle) ? default(PhpString) : fread(ctx, handle, 1);
         }
 
         /// <summary>
@@ -658,7 +658,7 @@ namespace Pchp.Library
                 return -1;
             }
 
-            if (data == null || data.IsEmpty)
+            if (data.IsEmpty)
             {
                 return 0;
             }
@@ -761,7 +761,7 @@ namespace Pchp.Library
         public static PhpString fgets(PhpResource handle)
         {
             PhpStream stream = PhpStream.GetValid(handle);
-            if (stream == null) return null;
+            if (stream == null) return default(PhpString);
 
             // Use the default accessor to the stream breaking at \n, no superfluous conversion.
             //return Core.Convert.Quote(stream.ReadData(-1, true), ScriptContext.CurrentContext);
@@ -802,7 +802,7 @@ namespace Pchp.Library
             }
 
             PhpStream stream = PhpStream.GetValid(handle);
-            if (stream == null) return null;
+            if (stream == null) return default(PhpString);
 
             // Use the default accessor to the stream breaking at \n, no superfluous conversion.
             //return Core.Convert.Quote(stream.ReadData(length, true), ScriptContext.CurrentContext);
@@ -915,11 +915,16 @@ namespace Pchp.Library
         {
             var sc = StreamContext.GetValid(context, true);
             if (sc == null)
-                return null;
+            {
+                return default(PhpString);
+            }
 
             using (PhpStream stream = PhpStream.Open(ctx, path, "rb", ProcessOptions(ctx, flags), sc))
             {
-                if (stream == null) return null;
+                if (stream == null)
+                {
+                    return default(PhpString);
+                }
 
                 // when HTTP protocol requested, store responded headers into local variable $http_response_header:
                 if (string.Compare(stream.Wrapper.Scheme, "http", StringComparison.OrdinalIgnoreCase) == 0)

--- a/src/Peachpie.Library/Hash.cs
+++ b/src/Peachpie.Library/Hash.cs
@@ -1980,7 +1980,7 @@ namespace Pchp.Library
         /// </summary>
         static PhpString HashBytes(Context ctx, HashAlgorithm/*!*/ algorithm, PhpString bytes, bool rawOutput = false)
         {
-            if (bytes == null) return null;
+            if (bytes.IsDefault) return default(PhpString);
 
             byte[] hash = algorithm.ComputeHash(bytes.ToBytes(ctx));
 
@@ -2002,18 +2002,18 @@ namespace Pchp.Library
                 //using (FileStream file = new FileStream(ctx, fileName, FileMode.Open, FileAccess.Read))
                 {
                     if (stream == null)
-                        return null;
+                        return default(PhpString);
 
                     var data = stream.ReadContents();
                     if (data.IsNull)
                     {
-                        return null;
+                        return default(PhpString);
                     }
 
                     var bytes = data.AsBytes(ctx.StringEncoding);
                     if (bytes == null)
                     {
-                        return null;
+                        return default(PhpString);
                     }
 
                     hash = algorithm.ComputeHash(bytes);
@@ -2021,7 +2021,7 @@ namespace Pchp.Library
             }
             catch (System.Exception)
             {
-                return null;
+                return default(PhpString);
             }
 
             return rawOutput
@@ -2159,7 +2159,7 @@ namespace Pchp.Library
             var h = ValidateHashResource(context);
             if (h == null)
             {
-                return null;
+                return default(PhpString);
             }
 
             byte[] hash = h.Final();
@@ -2289,7 +2289,7 @@ namespace Pchp.Library
             var h = hash_init(algo);
             if (h == null || !hash_update(h, data))
             {
-                return null;
+                return default(PhpString);
             }
 
             return hash_final(h, raw_output);
@@ -2301,7 +2301,7 @@ namespace Pchp.Library
             var h = hash_init(algo);
             if (h == null || !hash_update_file(ctx, h, filename))
             {
-                return null;
+                return default(PhpString);
             }
 
             return hash_final(h, raw_output);
@@ -2317,7 +2317,7 @@ namespace Pchp.Library
             var h = hash_init(algo, HashInitOptions.HASH_HMAC, key);
             if (h == null || !hash_update(h, data))
             {
-                return null;
+                return default(PhpString);
             }
 
             return hash_final(h, raw_output);
@@ -2329,7 +2329,7 @@ namespace Pchp.Library
             var h = hash_init(algo, HashInitOptions.HASH_HMAC, key);
             if (h == null || !hash_update_file(ctx, h, filename))
             {
-                return null;
+                return default(PhpString);
             }
 
             return hash_final(h, raw_output);

--- a/src/Peachpie.Library/MultiByteString.cs
+++ b/src/Peachpie.Library/MultiByteString.cs
@@ -709,9 +709,9 @@ namespace Pchp.Library
         /// <summary>
         /// Check if the string is valid for the specified encoding
         /// </summary>
-        public static bool mb_check_encoding(Context ctx, PhpString var = null, string encoding = null/*mb_internal_encoding()*/)
+        public static bool mb_check_encoding(Context ctx, PhpString var = default(PhpString), string encoding = null/*mb_internal_encoding()*/)
         {
-            if (var == null)
+            if (var.IsDefault)
             {
                 // NS: check all the input from the beginning of the request
                 throw new NotSupportedException();

--- a/src/Peachpie.Library/MultiByteString.cs
+++ b/src/Peachpie.Library/MultiByteString.cs
@@ -233,7 +233,7 @@ namespace Pchp.Library
             switch (value.TypeCode)
             {
                 case PhpTypeCode.String: return value.String;
-                case PhpTypeCode.WritableString: return ToString(ctx, value.WritableString, forceencoding);
+                case PhpTypeCode.MutableString: return ToString(ctx, value.MutableString, forceencoding);
                 case PhpTypeCode.Alias: return ToString(ctx, value.Alias.Value, forceencoding);
                 default: return value.ToStringOrThrow(ctx);
             }

--- a/src/Peachpie.Library/Serialization.Json.cs
+++ b/src/Peachpie.Library/Serialization.Json.cs
@@ -85,7 +85,7 @@ namespace Pchp.Library
                 /// <summary>
                 /// Result data.
                 /// </summary>
-                readonly PhpString _result = new PhpString();
+                readonly PhpString.Blob _result = new PhpString.Blob();
 
                 readonly Context _ctx;
                 readonly RuntimeTypeHandle _caller;
@@ -115,7 +115,7 @@ namespace Pchp.Library
                 {
                     ObjectWriter writer;
                     variable.Accept(writer = new ObjectWriter(ctx, encodeOptions, caller));
-                    return writer._result;
+                    return new PhpString(writer._result);
                 }
 
                 bool PushObject(object obj)

--- a/src/Peachpie.Library/Serialization.cs
+++ b/src/Peachpie.Library/Serialization.cs
@@ -48,7 +48,7 @@ namespace Pchp.Library
                 catch (Exception e)
                 {
                     PhpException.Throw(PhpError.Notice, LibResources.serialization_failed, e.Message);
-                    return null;
+                    return default(PhpString);
                 }
             }
 
@@ -186,14 +186,14 @@ namespace Pchp.Library
                 /// <summary>
                 /// Result data.
                 /// </summary>
-                readonly PhpString _result = new PhpString();
+                readonly PhpString.Blob _result = new PhpString.Blob();
 
                 readonly Context _ctx;
                 readonly RuntimeTypeHandle _caller;
 
                 void Write(char ch) => Write(ch.ToString());
-                void Write(string str) => _result.Append(str);
-                void Write(byte[] bytes) => _result.Append(bytes);
+                void Write(string str) => _result.Add(str);
+                void Write(byte[] bytes) => _result.Add(bytes);
                 void Write(PhpString str)
                 {
                     if (!str.IsEmpty)
@@ -216,7 +216,7 @@ namespace Pchp.Library
                 {
                     ObjectWriter writer;
                     variable.Accept(writer = new ObjectWriter(ctx, caller));
-                    return writer._result;
+                    return new PhpString(writer._result);
                 }
 
                 public override void AcceptNull()
@@ -388,7 +388,7 @@ namespace Pchp.Library
                     if (serializable != null)
                     {
                         var res = serializable.serialize();
-                        if (res == null)
+                        if (res.IsDefault)
                         {
                             AcceptNull();
                             return;

--- a/src/Peachpie.Library/Session.cs
+++ b/src/Peachpie.Library/Session.cs
@@ -239,15 +239,13 @@ namespace Pchp.Library
 
                 // 3. read
                 var str = _handler.read(GetSessionId(webctx));
-                if (str != null)
-                {
-                    var handler = GetSerializeHandler((Context)webctx);
-                    return handler.Deserialize((Context)webctx, str, default(RuntimeTypeHandle)).AsArray();
-                }
-                else
+                if (str.IsEmpty)
                 {
                     return null;
                 }
+
+                var handler = GetSerializeHandler((Context)webctx);
+                return handler.Deserialize((Context)webctx, str, default(RuntimeTypeHandle)).AsArray();
             }
 
             public override bool Persist(IHttpPhpContext webctx, PhpArray session)

--- a/src/Peachpie.Library/Spl/SplObjectStorage.cs
+++ b/src/Peachpie.Library/Spl/SplObjectStorage.cs
@@ -259,7 +259,7 @@ namespace Pchp.Library.Spl
         {
             // x:{count_int};{item0},{value0};;...;;m:{members_array}
 
-            var result = new PhpString();
+            var result = new PhpString.Blob();
             var serializer = PhpSerialization.PhpSerializer.Instance;
 
             // x:i:{count};
@@ -281,7 +281,7 @@ namespace Pchp.Library.Spl
             result.Append(serializer.Serialize(_ctx, (PhpValue)(__peach__runtimeFields ?? PhpArray.Empty), default(RuntimeTypeHandle)));
 
             //
-            return result;
+            return new PhpString(result);
         }
 
         /// <summary>

--- a/src/Peachpie.Library/Streams/Filters.cs
+++ b/src/Peachpie.Library/Streams/Filters.cs
@@ -76,7 +76,6 @@ namespace Pchp.Library.Streams
 
         public TextElement(PhpString str, Encoding encoding)
         {
-            Debug.Assert(str != null);
             _data = str.ContainsBinaryData
                 ? (object)str.ToBytes(encoding)
                 : str.ToString(encoding);

--- a/src/Peachpie.Library/Streams/Filters.cs
+++ b/src/Peachpie.Library/Streams/Filters.cs
@@ -94,8 +94,8 @@ namespace Pchp.Library.Streams
                     }
                     goto default;
 
-                case PhpTypeCode.WritableString:
-                    return new TextElement(value.WritableString, ctx.StringEncoding);
+                case PhpTypeCode.MutableString:
+                    return new TextElement(value.MutableString, ctx.StringEncoding);
 
                 default:
                     return new TextElement(value.ToStringOrThrow(ctx));

--- a/src/Peachpie.Library/Streams/Streams.cs
+++ b/src/Peachpie.Library/Streams/Streams.cs
@@ -799,7 +799,7 @@ namespace Pchp.Library.Streams
             var stream = PhpStream.GetValid(handle, FileAccess.Read);
             if (stream == null)
             {
-                return null;
+                return default(PhpString);
             }
 
             return stream.ReadContents(maxLength, offset).ToPhpString();

--- a/src/Peachpie.Library/Strings.cs
+++ b/src/Peachpie.Library/Strings.cs
@@ -72,7 +72,7 @@ namespace Pchp.Library
         /// </returns>
         public static string bin2hex(Context ctx, PhpString str)
         {
-            if (str == null || str.IsEmpty)
+            if (str.IsEmpty)
             {
                 return string.Empty;
             }
@@ -309,7 +309,7 @@ namespace Pchp.Library
 
         public static PhpString convert_cyr_string(byte[] bytes, string srcCharset, string dstCharset)
         {
-            if (bytes == null) return null;
+            if (bytes == null) return default(PhpString);
             if (bytes.Length == 0) return new PhpString();
 
             // checks srcCharset argument:
@@ -417,7 +417,7 @@ namespace Pchp.Library
         /// <returns>The array of characters frequency.</returns>
         public static PhpArray count_chars(Context ctx, PhpString bytes)
         {
-            if (bytes == null || bytes.IsEmpty)
+            if (bytes.IsEmpty)
             {
                 return PhpArray.NewEmpty();
             }
@@ -816,25 +816,25 @@ namespace Pchp.Library
             bool not_first = false;                       // not the first iteration
 
             var glue_element = Streams.TextElement.FromValue(ctx, glue);    // convert it once
-            var result = new PhpString();
+            var result = new PhpString.Blob();
 
             using (var x = pieces.GetFastEnumerator())
                 while (x.MoveNext())
                 {
                     if (not_first)
                     {
-                        if (glue_element.IsText) result.Append(glue_element.GetText());
-                        else result.Append(glue_element.GetBytes());
+                        if (glue_element.IsText) result.Add(glue_element.GetText());
+                        else result.Add(glue_element.GetBytes());
                     }
                     else
                     {
                         not_first = true;
                     }
 
-                    result.Append(x.CurrentValue, ctx);
+                    result.Add(x.CurrentValue, ctx);
                 }
 
-            return result;
+            return new PhpString(result);
         }
 
         #endregion
@@ -1597,10 +1597,10 @@ namespace Pchp.Library
                 return new PhpArray();
             }
 
-            var phpstr = obj.GetValue().Object as PhpString;
-            if (phpstr != null && phpstr.ContainsBinaryData)
+            var bytes = obj.AsBytesOrNull(ctx);
+            if (bytes != null)
             {
-                return Split(phpstr.ToBytes(ctx.StringEncoding), splitLength);
+                return Split(bytes, splitLength);
             }
             else
             {

--- a/src/Peachpie.Library/Utils.cs
+++ b/src/Peachpie.Library/Utils.cs
@@ -173,14 +173,14 @@ namespace Pchp.Library
         /// <returns>String representation of <paramref name="str"/>.</returns>
         internal static string ToString(this PhpString str, string charSet)
         {
-            if (str == null)
+            if (str.IsEmpty)
             {
                 return string.Empty;
             }
 
             Encoding encoding;
 
-            if (str != null && str.ContainsBinaryData)
+            if (str.ContainsBinaryData)
             {
                 encoding = Encoding.GetEncoding(charSet);
 

--- a/src/Peachpie.Library/Variables.cs
+++ b/src/Peachpie.Library/Variables.cs
@@ -765,7 +765,7 @@ namespace Pchp.Library
             readonly protected Context _ctx;
             readonly protected string _nl;
 
-            protected PhpString _output;
+            protected PhpString.Blob _output;
             protected int _indent;
 
             protected const string RECURSION = "*RECURSION*";
@@ -779,13 +779,13 @@ namespace Pchp.Library
 
             public virtual PhpString Serialize(PhpValue value)
             {
-                _output = new PhpString();
+                _output = new PhpString.Blob();
                 _indent = 0;
 
                 //
                 Accept(value);
 
-                return _output;
+                return new PhpString(_output);
             }
 
             /// <summary>
@@ -1060,9 +1060,9 @@ namespace Pchp.Library
 
             public override PhpString Serialize(PhpValue value)
             {
-                var output = base.Serialize(value);
-                output.Append(_nl);
-                return output;
+                base.Serialize(value);
+                _output.Append(_nl);
+                return new PhpString(_output);
             }
 
             public override void Accept(bool obj)

--- a/src/Peachpie.Library/Variables.cs
+++ b/src/Peachpie.Library/Variables.cs
@@ -317,7 +317,7 @@ namespace Pchp.Library
                     return true;
 
                 case "string":
-                    if (variable.TypeCode != PhpTypeCode.WritableString)    // already a string with possible binary data
+                    if (variable.TypeCode != PhpTypeCode.MutableString)    // already a string with possible binary data
                     {
                         variable = PhpValue.Create(variable.ToString(ctx));
                     }
@@ -413,7 +413,7 @@ namespace Pchp.Library
         /// </summary>
         /// <param name="variable">The variable.</param>
         /// <returns>Whether <paramref name="variable"/> is string.</returns>
-        public static bool is_string(PhpValue variable) => variable.TypeCode == PhpTypeCode.String || variable.TypeCode == PhpTypeCode.WritableString || (variable.IsAlias && is_string(variable.Alias.Value));
+        public static bool is_string(PhpValue variable) => variable.TypeCode == PhpTypeCode.String || variable.TypeCode == PhpTypeCode.MutableString || (variable.IsAlias && is_string(variable.Alias.Value));
 
         /// <summary>
         /// Checks whether a dereferenced variable is an <see cref="PhpArray"/>.
@@ -491,7 +491,7 @@ namespace Pchp.Library
                     return true;
 
                 case PhpTypeCode.String:
-                case PhpTypeCode.WritableString:
+                case PhpTypeCode.MutableString:
                     PhpNumber tmp;
                     return (variable.ToNumber(out tmp) & Core.Convert.NumberInfo.IsNumber) != 0;
 

--- a/src/Peachpie.Library/Web.cs
+++ b/src/Peachpie.Library/Web.cs
@@ -37,7 +37,7 @@ namespace Pchp.Library
         {
             if (encoded_data == null)
             {
-                return null;
+                return default(PhpString);
             }
 
             try
@@ -55,11 +55,6 @@ namespace Pchp.Library
         [return: CastToFalse]
         public static string base64_encode(Context ctx, PhpString data_to_encode)
         {
-            if (data_to_encode == null)
-            {
-                return null;
-            }
-
             return System.Convert.ToBase64String(data_to_encode.ToBytes(ctx.StringEncoding));
         }
 

--- a/src/Peachpie.Library/iconv.cs
+++ b/src/Peachpie.Library/iconv.cs
@@ -260,9 +260,9 @@ namespace Pchp.Library
                         string
                             strChar = line.Substring(0, t1),
                             str = line.Substring(t1 + 1, t2 - t1);
-                        
+
                         int charNumber = int.Parse(strChar, System.Globalization.NumberStyles.HexNumber);
-                        
+
                         if (transliterationsMaxCharCount < str.Length)
                             transliterationsMaxCharCount = str.Length;
 
@@ -498,7 +498,7 @@ namespace Pchp.Library
         /// <returns>Returns the character count of str, as an integer.</returns>
         public static int iconv_strlen(Context ctx, PhpString str, string charset = null/*=iconv.internal_encoding*/)
         {
-            if (str == null || str.IsEmpty)
+            if (str.IsEmpty)
             {
                 return 0;
             }
@@ -529,7 +529,7 @@ namespace Pchp.Library
         [return: CastToFalse]
         public static int iconv_strpos(Context ctx, PhpString haystack, PhpString needle, int offset = 0, string charset = null/*= ini_get("iconv.internal_encoding")*/)
         {
-            if (haystack == null || needle == null)
+            if (haystack.IsEmpty || needle.IsEmpty)
                 return -1;
 
             var encoding = ResolveEncoding(ctx, charset);
@@ -551,7 +551,7 @@ namespace Pchp.Library
         [return: CastToFalse]
         public static int iconv_strrpos(Context ctx, PhpString haystack, PhpString needle, string charset = null /*= ini_get("iconv.internal_encoding")*/)
         {
-            if (haystack == null || needle == null)
+            if (haystack.IsEmpty || needle.IsEmpty)
                 return -1;
 
             var encoding = ResolveEncoding(ctx, charset);
@@ -577,7 +577,7 @@ namespace Pchp.Library
         [return: CastToFalse]
         public static string iconv_substr(Context ctx, PhpString str, int offset, int length = int.MaxValue /*= iconv_strlen($str, $charset)*/ , string charset = null /*= ini_get("iconv.internal_encoding")*/)
         {
-            if (str == null)
+            if (str.IsEmpty)
                 return null;
 
             if (str.ContainsBinaryData)
@@ -613,15 +613,15 @@ namespace Pchp.Library
         public static PhpString iconv(Context ctx, string in_charset, string out_charset, PhpString str)
         {
             // check args
-            if (str == null)
+            if (str.IsDefault)
             {
                 PhpException.ArgumentNull("str");
-                return null;
+                return default(PhpString);
             }
             if (out_charset == null)
             {
                 PhpException.ArgumentNull("out_charset");
-                return null;
+                return default(PhpString);
             }
 
             // resolve out_charset
@@ -631,7 +631,7 @@ namespace Pchp.Library
             if (out_encoding == null)
             {
                 PhpException.Throw(PhpError.Notice, Resources.LibResources.wrong_charset, out_charset, in_charset, out_charset);
-                return null;
+                return default(PhpString);
             }
 
             // encoding fallback
@@ -644,7 +644,7 @@ namespace Pchp.Library
                 enc_fallback = new IgnoreEncoderFallback();    // ignore character and continue
             else
                 enc_fallback = new StopEncoderFallback(out_result);    // throw notice and discard all remaining characters
-            
+
             //// out_encoding.Clone() ensures it is NOT readOnly
             //// then set EncoderFallback to catch handle unconvertable characters
 
@@ -660,13 +660,13 @@ namespace Pchp.Library
                     if (in_charset == null)
                     {
                         PhpException.ArgumentNull("in_charset");
-                        return null;
+                        return default(PhpString);
                     }
                     var in_encoding = ResolveEncoding(ctx, in_charset);
                     if (in_encoding == null)
                     {
                         PhpException.Throw(PhpError.Notice, Resources.LibResources.wrong_charset, in_charset, in_charset, out_charset);
-                        return null;
+                        return default(PhpString);
                     }
 
                     // TODO: in_encoding.Clone() ensures it is NOT readOnly, then set DecoderFallback to catch invalid byte sequences
@@ -675,7 +675,7 @@ namespace Pchp.Library
                     return new PhpString(out_encoding.GetBytes(str.ToString(in_encoding)));
                 }
                 else
-                { 
+                {
                     // convert UTF16 to <out_charset>
                     return new PhpString(str.ToBytes(out_encoding));
                 }

--- a/src/Peachpie.Library/zlib.cs
+++ b/src/Peachpie.Library/zlib.cs
@@ -122,7 +122,7 @@ namespace Pchp.Library
             if (level < -1 || level > 9)
             {
                 PhpException.Throw(PhpError.Warning, String.Format("compression level ({0}) must be within -1..9", level));
-                return null;
+                return default(PhpString);
             }
 
             var zs = new ZStream();
@@ -163,7 +163,7 @@ namespace Pchp.Library
             else
             {
                 PhpException.Throw(PhpError.Warning, zError(status));
-                return null;
+                return default(PhpString);
             }
         }
 
@@ -199,7 +199,7 @@ namespace Pchp.Library
             if (status != zlibConst.Z_OK)
             {
                 PhpException.Throw(PhpError.Warning, zError(status));
-                return null;
+                return default(PhpString);
             }
 
             do
@@ -220,7 +220,7 @@ namespace Pchp.Library
                 catch (OutOfMemoryException)
                 {
                     zs.inflateEnd();
-                    return null;
+                    return default(PhpString);
                 }
 
                 zs.next_out_index = (int)zs.total_out;
@@ -245,7 +245,7 @@ namespace Pchp.Library
             else
             {
                 PhpException.Throw(PhpError.Warning, zError(status));
-                return null;
+                return default(PhpString);
             }
         }
 
@@ -305,7 +305,7 @@ namespace Pchp.Library
             if ((level < -1) || (level > 9))
             {
                 PhpException.Throw(PhpError.Warning, String.Format("compression level ({0}) must be within -1..9", level));
-                return null;
+                return default(PhpString);
             }
 
             if (data == null)
@@ -323,7 +323,7 @@ namespace Pchp.Library
             }
             catch (OutOfMemoryException)
             {
-                return null;
+                return default(PhpString);
             }
 
             int status;
@@ -337,7 +337,7 @@ namespace Pchp.Library
             else
             {
                 PhpException.Throw(PhpError.Warning, zError(status));
-                return null;
+                return default(PhpString);
             }
         }
 
@@ -361,7 +361,7 @@ namespace Pchp.Library
             if (length < 0)
             {
                 PhpException.Throw(PhpError.Warning, String.Format("length {0} must be greater or equal zero", length));
-                return null;
+                return default(PhpString);
             }
 
             int ilength;
@@ -379,7 +379,7 @@ namespace Pchp.Library
                 }
                 catch (OutOfMemoryException)
                 {
-                    return null;
+                    return default(PhpString);
                 }
 
                 status = ZlibUncompress(ref output, data);
@@ -393,7 +393,7 @@ namespace Pchp.Library
             else
             {
                 PhpException.Throw(PhpError.Warning, zError(status));
-                return null;
+                return default(PhpString);
             }
         }
 
@@ -484,7 +484,7 @@ namespace Pchp.Library
         public static PhpString gzdecode(byte[] data, int length = 0)
         {
             PhpException.FunctionNotSupported("gzdecode");
-            return null;
+            return default(PhpString);
         }
 
         /// <summary>
@@ -509,7 +509,7 @@ namespace Pchp.Library
             if ((level < -1) || (level > 9))
             {
                 PhpException.Throw(PhpError.Warning, "compression level ({0}) must be within -1..9", level.ToString());
-                return null;
+                return default(PhpString);
             }
 
             ZStream zs = new ZStream();
@@ -528,14 +528,14 @@ namespace Pchp.Library
                     if ((status = zs.deflateInit(level, -MAX_WBITS)) != zlibConst.Z_OK)
                     {
                         PhpException.Throw(PhpError.Warning, zError(status));
-                        return null;
+                        return default(PhpString);
                     }
                     break;
                 case (int)ForceConstants.FORCE_DEFLATE:
                     if ((status = zs.deflateInit(level)) != zlibConst.Z_OK)
                     {
                         PhpException.Throw(PhpError.Warning, zError(status));
-                        return null;
+                        return default(PhpString);
                     }
                     break;
             }
@@ -595,7 +595,7 @@ namespace Pchp.Library
             else
             {
                 PhpException.Throw(PhpError.Warning, zError(status));
-                return null;
+                return default(PhpString);
             }
         }
 

--- a/src/Peachpie.Runtime/Comparison.cs
+++ b/src/Peachpie.Runtime/Comparison.cs
@@ -46,8 +46,8 @@ namespace Pchp.Core
                 case PhpTypeCode.String:
                     return x.String.Length == 0;
 
-                case PhpTypeCode.WritableString:
-                    return x.WritableString.IsEmpty;
+                case PhpTypeCode.MutableString:
+                    return x.MutableString.IsEmpty;
 
                 case PhpTypeCode.Alias:
                     return CeqNull(x.Alias.Value);
@@ -65,7 +65,7 @@ namespace Pchp.Core
                 case PhpTypeCode.Boolean: return Compare(lx != 0, y.Boolean);
                 case PhpTypeCode.Double: return Compare((double)lx, y.Double);
                 case PhpTypeCode.String: return -Compare(y.String, lx);
-                case PhpTypeCode.WritableString: return -Compare(y.WritableString.ToString(), lx);
+                case PhpTypeCode.MutableString: return -Compare(y.MutableString.ToString(), lx);
                 case PhpTypeCode.PhpArray: return -1;
                 case PhpTypeCode.Alias: return Compare(lx, y.Alias.Value);
                 case PhpTypeCode.Null:
@@ -86,7 +86,7 @@ namespace Pchp.Core
                 case PhpTypeCode.Long: return Compare(dx, (double)y.Long);
                 case PhpTypeCode.Boolean: return Compare(dx != 0.0, y.Boolean);
                 case PhpTypeCode.String: return -Compare(y.String, dx);
-                case PhpTypeCode.WritableString: return -Compare(y.WritableString.ToString(), dx);
+                case PhpTypeCode.MutableString: return -Compare(y.MutableString.ToString(), dx);
                 case PhpTypeCode.PhpArray: return -1;
                 case PhpTypeCode.Alias: return Compare(dx, y.Alias.Value);
                 case PhpTypeCode.Null:
@@ -111,7 +111,7 @@ namespace Pchp.Core
                 case PhpTypeCode.Long: return Compare(sx, y.Long);
                 case PhpTypeCode.Boolean: return Compare(Convert.ToBoolean(sx), y.Boolean);
                 case PhpTypeCode.String: return Compare(sx, y.String);
-                case PhpTypeCode.WritableString: return Compare(sx, y.WritableString.ToString());
+                case PhpTypeCode.MutableString: return Compare(sx, y.MutableString.ToString());
                 case PhpTypeCode.Alias: return Compare(sx, y.Alias.Value);
                 case PhpTypeCode.PhpArray: return -1;   // - 1 * (array.CompareTo(string))
                 case PhpTypeCode.Null:
@@ -275,7 +275,7 @@ namespace Pchp.Core
                 case PhpTypeCode.Long: return y.Long == 0 ? 0 : -1;
                 case PhpTypeCode.Double: return y.Double == 0 ? 0 : -1;
                 case PhpTypeCode.String: return y.String.Length == 0 ? 0 : -1;
-                case PhpTypeCode.WritableString: return y.WritableString.Length == 0 ? 0 : -1;
+                case PhpTypeCode.MutableString: return y.MutableString.Length == 0 ? 0 : -1;
                 case PhpTypeCode.PhpArray: return -y.Array.Count;
                 case PhpTypeCode.Alias: return CompareNull(y.Alias.Value);
                 case PhpTypeCode.Undefined:

--- a/src/Peachpie.Runtime/Conversions.cs
+++ b/src/Peachpie.Runtime/Conversions.cs
@@ -70,7 +70,7 @@ namespace Pchp.Core
     [DebuggerNonUserCode]
     public static class Convert
     {
-        #region ToString
+        #region ToString, ToBytes
 
         /// <summary>
         /// Gets string representation of a boolean value (according to PHP, it is <c>"1"</c> or <c>""</c>).
@@ -111,6 +111,16 @@ namespace Pchp.Core
                 return value.ToString();
             }
         }
+
+        /// <summary>
+        /// Converts mutable string to string.
+        /// </summary>
+        public static string ToString(PhpString value, Context ctx) => value.ToString(ctx);
+
+        /// <summary>
+        /// Converts mutable string to byte[].
+        /// </summary>
+        public static byte[] ToBytes(PhpString value, Context ctx) => value.ToBytes(ctx);
 
         #endregion
 
@@ -172,6 +182,11 @@ namespace Pchp.Core
             // not "0"
             return value != null && value.Length != 0 && (value.Length != 1 || value[0] != '0');
         }
+
+        /// <summary>
+        /// Converts string to boolean according to PHP.
+        /// </summary>
+        public static bool ToBoolean(PhpString value) => value.ToBoolean();
 
         /// <summary>
         /// Converts class instance to boolean according to PHP.
@@ -358,6 +373,11 @@ namespace Pchp.Core
 
             return n;
         }
+
+        /// <summary>
+        /// Performs conversion of a value to a number.
+        /// </summary>
+        public static PhpNumber ToNumber(PhpString value) => value.ToNumber();
 
         #endregion
 

--- a/src/Peachpie.Runtime/Conversions.cs
+++ b/src/Peachpie.Runtime/Conversions.cs
@@ -273,8 +273,8 @@ namespace Pchp.Core
                 case PhpTypeCode.Alias:
                     return ToPhpString(value.Alias.Value, ctx);
 
-                case PhpTypeCode.WritableString:
-                    return value.WritableString;
+                case PhpTypeCode.MutableString:
+                    return value.MutableString;
                 case PhpTypeCode.String:
                     return new PhpString(value.String);
                 default:

--- a/src/Peachpie.Runtime/Dynamic/Cache.cs
+++ b/src/Peachpie.Runtime/Dynamic/Cache.cs
@@ -84,6 +84,7 @@ namespace Pchp.Core.Dynamic
             public static ConstructorInfo ctor_ByteArray = typeof(Core.PhpString).GetCtor(typeof(byte[]));
             public static readonly MethodInfo ToString_Context = typeof(Core.PhpString).GetMethod("ToString", typeof(Context));
             public static readonly MethodInfo ToBytes_Context = typeof(Core.PhpString).GetMethod("ToBytes", typeof(Context));
+            public static readonly PropertyInfo IsDefault = Types.PhpString[0].GetTypeInfo().GetDeclaredProperty("IsDefault");
         }
 
         public static class IntStringKey

--- a/src/Peachpie.Runtime/Dynamic/ConvertExpression.cs
+++ b/src/Peachpie.Runtime/Dynamic/ConvertExpression.cs
@@ -591,7 +591,7 @@ namespace Pchp.Core.Dynamic
                 case PhpTypeCode.Int32:
                 case PhpTypeCode.Long:
                 case PhpTypeCode.Double:
-                case PhpTypeCode.WritableString:
+                case PhpTypeCode.MutableString:
                 case PhpTypeCode.String:
                     return ConversionCost.LoosingPrecision;
 
@@ -617,7 +617,7 @@ namespace Pchp.Core.Dynamic
                     return ConversionCost.ImplicitCast;
 
                 case PhpTypeCode.Double:
-                case PhpTypeCode.WritableString:
+                case PhpTypeCode.MutableString:
                 case PhpTypeCode.String:
                     return ConversionCost.LoosingPrecision;
 
@@ -640,8 +640,8 @@ namespace Pchp.Core.Dynamic
                 case PhpTypeCode.Object:
                     return ConversionCost.ImplicitCast;
 
-                case PhpTypeCode.WritableString:
-                    return value.WritableString.ContainsBinaryData ? ConversionCost.LoosingPrecision : ConversionCost.PassCostly;
+                case PhpTypeCode.MutableString:
+                    return value.MutableString.ContainsBinaryData ? ConversionCost.LoosingPrecision : ConversionCost.PassCostly;
 
                 case PhpTypeCode.String:
                     return ConversionCost.Pass;
@@ -665,7 +665,7 @@ namespace Pchp.Core.Dynamic
                 case PhpTypeCode.Object:
                     return ConversionCost.ImplicitCast;
 
-                case PhpTypeCode.WritableString:
+                case PhpTypeCode.MutableString:
                     return ConversionCost.Pass;
 
                 case PhpTypeCode.String:
@@ -691,7 +691,7 @@ namespace Pchp.Core.Dynamic
                 case PhpTypeCode.Double:
                     return ConversionCost.Pass;
 
-                case PhpTypeCode.WritableString:
+                case PhpTypeCode.MutableString:
                 case PhpTypeCode.String:
                     return ConversionCost.LoosingPrecision;
 
@@ -715,7 +715,7 @@ namespace Pchp.Core.Dynamic
                 case PhpTypeCode.Boolean:
                     return ConversionCost.ImplicitCast;
 
-                case PhpTypeCode.WritableString:
+                case PhpTypeCode.MutableString:
                 case PhpTypeCode.String:
                     return ConversionCost.LoosingPrecision;
 
@@ -735,7 +735,7 @@ namespace Pchp.Core.Dynamic
                 case PhpTypeCode.Long:
                 case PhpTypeCode.Double:
                 case PhpTypeCode.Boolean:
-                case PhpTypeCode.WritableString:
+                case PhpTypeCode.MutableString:
                 case PhpTypeCode.String:
                     return ConversionCost.Warning;
 

--- a/src/Peachpie.Runtime/Dynamic/OverloadBinder.cs
+++ b/src/Peachpie.Runtime/Dynamic/OverloadBinder.cs
@@ -957,7 +957,7 @@ namespace Pchp.Core.Dynamic
                 else if (expr.Type == typeof(PhpString))
                 {
                     // Template: test = !x.IsDefault
-                    test = Expression.Negate(Expression.Property(assign, Cache.PhpString.IsDefault));
+                    test = Expression.Not(Expression.Property(assign, Cache.PhpString.IsDefault));
                 }
                 else if (expr.Type.GetTypeInfo().IsValueType == false)  // reference type
                 {

--- a/src/Peachpie.Runtime/Dynamic/OverloadBinder.cs
+++ b/src/Peachpie.Runtime/Dynamic/OverloadBinder.cs
@@ -954,6 +954,11 @@ namespace Pchp.Core.Dynamic
                     // Template: test = x >= 0.0
                     test = Expression.GreaterThanOrEqual(assign, Expression.Constant(0.0));
                 }
+                else if (expr.Type == typeof(PhpString))
+                {
+                    // Template: test = !x.IsDefault
+                    test = Expression.Negate(Expression.Property(assign, Cache.PhpString.IsDefault));
+                }
                 else if (expr.Type.GetTypeInfo().IsValueType == false)  // reference type
                 {
                     // Template: test = x != null

--- a/src/Peachpie.Runtime/Errors.cs
+++ b/src/Peachpie.Runtime/Errors.cs
@@ -251,7 +251,7 @@ namespace Pchp.Core
             {
                 Throw(PhpError.Warning, ErrResources.array_used_as_object);
             }
-            else if (var.TypeCode == PhpTypeCode.String || var.TypeCode == PhpTypeCode.WritableString)
+            else if (var.TypeCode == PhpTypeCode.String || var.TypeCode == PhpTypeCode.MutableString)
             {
                 Throw(PhpError.Warning, reference ? ErrResources.string_item_used_as_reference : ErrResources.string_used_as_object);
             }

--- a/src/Peachpie.Runtime/Operators.cs
+++ b/src/Peachpie.Runtime/Operators.cs
@@ -120,7 +120,7 @@ namespace Pchp.Core
                 case PhpTypeCode.Alias: return BitNot(ref x.Alias.Value);
 
                 case PhpTypeCode.String:
-                case PhpTypeCode.WritableString:
+                case PhpTypeCode.MutableString:
                     throw new NotImplementedException();    // bitwise negation of each character in string
 
                 case PhpTypeCode.Object:

--- a/src/Peachpie.Runtime/PhpString.cs
+++ b/src/Peachpie.Runtime/PhpString.cs
@@ -402,8 +402,8 @@ namespace Pchp.Core
                         Add(value.String);
                         break;
 
-                    case PhpTypeCode.WritableString:
-                        Add(value.StringBlob);
+                    case PhpTypeCode.MutableString:
+                        Add(value.MutableStringBlob);
                         break;
 
                     case PhpTypeCode.Alias:
@@ -833,8 +833,8 @@ namespace Pchp.Core
                         ch = (value.String.Length != 0) ? value.String[0] : '\0';
                         break;
 
-                    case PhpTypeCode.WritableString:
-                        ch = value.StringBlob[0];
+                    case PhpTypeCode.MutableString:
+                        ch = value.MutableStringBlob[0];
                         break;
 
                     // TODO: other types

--- a/src/Peachpie.Runtime/PhpString.cs
+++ b/src/Peachpie.Runtime/PhpString.cs
@@ -403,7 +403,7 @@ namespace Pchp.Core
                         break;
 
                     case PhpTypeCode.WritableString:
-                        Add(value.WritableString.ContainingBlob);
+                        Add(value.StringBlob);
                         break;
 
                     case PhpTypeCode.Alias:
@@ -834,7 +834,7 @@ namespace Pchp.Core
                         break;
 
                     case PhpTypeCode.WritableString:
-                        ch = value.WritableString[0];
+                        ch = value.StringBlob[0];
                         break;
 
                     // TODO: other types
@@ -1037,7 +1037,13 @@ namespace Pchp.Core
         /// <summary>
         /// Gets instance of blob that is not shared.
         /// </summary>
-        public static Blob EnsureWritable(PhpString str) => str.EnsureWritable();
+        public static Blob AsWritable(PhpString str) => str.EnsureWritable();
+
+        /// <summary>
+        /// Gets read-only array access to the string.
+        /// For write access, use <see cref="EnsureWritable()"/>.
+        /// </summary>
+        public static Blob AsArray(PhpString str) => str._blob ?? new Blob();
 
         public override string ToString() => _blob.ToString(Encoding.UTF8);
 

--- a/src/Peachpie.Runtime/PhpString.cs
+++ b/src/Peachpie.Runtime/PhpString.cs
@@ -1014,10 +1014,6 @@ namespace Pchp.Core
             {
                 return _blob[index];
             }
-            set
-            {
-                EnsureWritable()[index] = value;
-            }
         }
 
         #endregion

--- a/src/Peachpie.Runtime/PhpString.cs
+++ b/src/Peachpie.Runtime/PhpString.cs
@@ -1,5 +1,6 @@
 ﻿using Pchp.Core.Utilities;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -9,13 +10,32 @@ using System.Threading.Tasks;
 
 namespace Pchp.Core
 {
+    #region IMutableString
+
+    /// <summary>
+    /// Provides access to <see cref="PhpString"/> with write access.
+    /// </summary>
+    public interface IMutableString : IPhpArray
+    {
+        void Add(string value);
+        void Add(byte[] value);
+        void Add(PhpString value);
+        void Add(PhpValue value, Context ctx);
+
+        char this[int index] { get; set; }
+
+        int Length { get; }
+    }
+
+    #endregion
+
     /// <summary>
     /// String builder providing fast concatenation and character replacements for hybrid strings (both unicode and binary).
     /// </summary>
     /// <remarks>Optimized for concatenation and output.</remarks>
     [DebuggerDisplay("{ToString()}", Type = PhpVariable.TypeNameString)]
     [DebuggerNonUserCode]
-    public sealed partial class PhpString : IPhpConvertible, IPhpArray
+    public struct PhpString : IPhpConvertible
     {
         //[StructLayout(LayoutKind.Explicit)]
         //struct Chunk
@@ -44,7 +64,8 @@ namespace Pchp.Core
         //    public bool IsPhpString => _obj != null && _obj.GetType() == typeof(PhpString);
         //}
 
-        internal sealed class Blob
+        [DebuggerDisplay("{DebugString}")]
+        public sealed class Blob : IMutableString
         {
             #region enum Flags
 
@@ -66,11 +87,11 @@ namespace Pchp.Core
             }
 
             #endregion
-            
+
             #region Fields
 
             /// <summary>
-            /// One string or concatenated string chunks of either <see cref="string"/>, <see cref="byte"/>[], <see cref="char"/>[] or <see cref="PhpString"/>.
+            /// One string or concatenated string chunks of either <see cref="string"/>, <see cref="byte"/>[], <see cref="char"/>[] or <see cref="Blob"/>.
             /// </summary>
             object _chunks;
 
@@ -101,6 +122,41 @@ namespace Pchp.Core
 
             #endregion
 
+            #region DebugString
+
+            string DebugString
+            {
+                get
+                {
+                    if (ContainsBinaryData)
+                    {
+                        var bytes = ToBytes(Encoding.UTF8);
+                        var str = new StringBuilder(bytes.Length);
+
+                        foreach (var b in bytes)
+                        {
+                            if (b < 0x7f && b >= 0x20)
+                            {
+                                str.Append((char)b);
+                            }
+                            else
+                            {
+                                str.Append("\\x");
+                                str.Append(b.ToString("x2"));
+                            }
+                        }
+
+                        return str.ToString();
+                    }
+                    else
+                    {
+                        return ToString(Encoding.UTF8);
+                    }
+                }
+            }
+
+            #endregion
+
             /// <summary>
             /// Gets value indicating the string contains <see cref="byte"/> instead of unicode <see cref="string"/>.
             /// </summary>
@@ -117,13 +173,11 @@ namespace Pchp.Core
             private bool IsArrayOfChunks => (_flags & Flags.IsArrayOfChunks) != 0;
 
             /// <summary>
-            /// Gets value indicating that this instance of data is shared accross more <see cref="PhpString"/> instances and cannot be written to.
+            /// Gets value indicating that this instance of data is shared and cannot be written to.
             /// </summary>
             public bool IsShared => _refs > 1;
 
             #region Construction
-
-            public static readonly Blob Empty = new Blob() { _refs = 999 };
 
             public Blob()
             {
@@ -136,11 +190,11 @@ namespace Pchp.Core
             {
                 if (string.IsNullOrEmpty(y))
                 {
-                    Append(x);
+                    Add(x);
                 }
                 else if (string.IsNullOrEmpty(x))
                 {
-                    Append(y);
+                    Add(y);
                 }
                 else
                 {
@@ -152,12 +206,12 @@ namespace Pchp.Core
 
             public Blob(string value)
             {
-                Append(value);
+                Add(value);
             }
 
             public Blob(byte[] value)
             {
-                Append(value);
+                Add(value);
             }
 
             private Blob(Blob blob)
@@ -221,7 +275,7 @@ namespace Pchp.Core
             {
                 AssertChunkObject(chunk);
                 if (chunk.GetType() == typeof(string)) { }  // immutable
-                else if (chunk.GetType() == typeof(PhpString)) chunk = ((PhpString)chunk).Clone();
+                else if (chunk.GetType() == typeof(Blob)) chunk = ((Blob)chunk).AddRef();
                 else chunk = ((Array)chunk).Clone();   // byte[], char[]
             }
 
@@ -270,7 +324,7 @@ namespace Pchp.Core
 
                 if (chunk.GetType() == typeof(string)) return ((string)chunk).Length;
                 if (chunk.GetType() == typeof(byte[])) return ((byte[])chunk).Length;
-                if (chunk.GetType() == typeof(PhpString)) return ((PhpString)chunk).Length;
+                if (chunk.GetType() == typeof(Blob)) return ((Blob)chunk).Length;
                 if (chunk.GetType() == typeof(char[])) return ((char[])chunk).Length;
                 throw new ArgumentException();
             }
@@ -289,9 +343,12 @@ namespace Pchp.Core
 
             #endregion
 
-            #region Append
+            #region Add, Append
 
-            public void Append(string value)
+            public void Append(string value) => Add(value);
+            public void Append(PhpString value) => Add(value);
+
+            public void Add(string value)
             {
                 if (!string.IsNullOrEmpty(value))
                 {
@@ -299,29 +356,28 @@ namespace Pchp.Core
                 }
             }
 
-            public void Append(PhpString value)
+            public void Add(Blob value)
             {
-                if (value != null && !value.IsEmpty)
+                Debug.Assert(value != null);
+                Debug.Assert(!value.IsEmpty);
+                Debug.Assert(value._chunks != null);
+
+                if (value.IsArrayOfChunks)
                 {
-                    Debug.Assert(value._blob._chunks != null);
-
-                    if (value._blob.IsArrayOfChunks)
-                    {
-                        AddChunk(value.DeepCopy());
-                    }
-                    else
-                    {
-                        // if containing only one chunk, add it directly
-                        var chunk = value._blob._chunks;
-                        InplaceDeepCopy(ref chunk);
-                        AddChunk(chunk);
-                    }
-
-                    _flags |= (value._blob._flags & (Flags.ContainsBinary | Flags.ContainsMutables));    // maintain the binary data flag
+                    AddChunk(value.AddRef());
                 }
+                else
+                {
+                    // if containing only one chunk, add it directly
+                    var chunk = value._chunks;
+                    InplaceDeepCopy(ref chunk);
+                    AddChunk(chunk);
+                }
+
+                _flags |= (value._flags & (Flags.ContainsBinary | Flags.ContainsMutables));    // maintain the binary data flag
             }
 
-            public void Append(byte[] value)
+            public void Add(byte[] value)
             {
                 if (value != null && value.Length != 0)
                 {
@@ -330,13 +386,44 @@ namespace Pchp.Core
                 }
             }
 
+            public void Add(PhpString value)
+            {
+                if (!value.IsEmpty)
+                {
+                    Add(value._blob);
+                }
+            }
+
+            public void Add(PhpValue value, Context ctx)
+            {
+                switch (value.TypeCode)
+                {
+                    case PhpTypeCode.String:
+                        Add(value.String);
+                        break;
+
+                    case PhpTypeCode.WritableString:
+                        Add(value.WritableString.ContainingBlob);
+                        break;
+
+                    case PhpTypeCode.Alias:
+                        Add(value.Alias.Value, ctx);
+                        break;
+
+                    default:
+                        Add(value.ToStringOrThrow(ctx));
+                        break;
+                }
+            }
+
             #endregion
 
             #region AddChunk
 
+            [Conditional("DEBUG")]
             static void AssertChunkObject(object chunk)
             {
-                Debug.Assert(chunk is byte[] || chunk is string || chunk is char[] || chunk is PhpString);
+                Debug.Assert(chunk is byte[] || chunk is string || chunk is char[] || chunk is Blob);
             }
 
             void AddChunk(object newchunk)
@@ -419,7 +506,7 @@ namespace Pchp.Core
 
                 if (chunk.GetType() == typeof(string)) ctx.Output.Write((string)chunk);
                 else if (chunk.GetType() == typeof(byte[])) ctx.OutputStream.Write((byte[])chunk);
-                else if (chunk.GetType() == typeof(PhpString)) ((PhpString)chunk).Output(ctx);
+                else if (chunk.GetType() == typeof(Blob)) ((Blob)chunk).Output(ctx);
                 else if (chunk.GetType() == typeof(char[])) ctx.Output.Write((char[])chunk);
                 else throw new ArgumentException();
             }
@@ -478,7 +565,7 @@ namespace Pchp.Core
 
                 if (chunk.GetType() == typeof(string)) return (string)chunk;
                 if (chunk.GetType() == typeof(byte[])) return encoding.GetString((byte[])chunk);
-                if (chunk.GetType() == typeof(PhpString)) return ((PhpString)chunk).ToString(encoding);
+                if (chunk.GetType() == typeof(Blob)) return ((Blob)chunk).ToString(encoding);
                 if (chunk.GetType() == typeof(char[])) return new string((char[])chunk);
                 throw new ArgumentException(chunk.GetType().ToString());
             }
@@ -532,7 +619,7 @@ namespace Pchp.Core
 
                 if (chunk.GetType() == typeof(byte[])) return (byte[])chunk;
                 if (chunk.GetType() == typeof(string)) return encoding.GetBytes((string)chunk);
-                if (chunk.GetType() == typeof(PhpString)) return ((PhpString)chunk).ToBytes(encoding);
+                if (chunk.GetType() == typeof(Blob)) return ((Blob)chunk).ToBytes(encoding);
                 if (chunk.GetType() == typeof(char[])) return encoding.GetBytes((char[])chunk);
                 throw new ArgumentException(chunk.GetType().ToString());
             }
@@ -580,11 +667,11 @@ namespace Pchp.Core
                     {
                         if (index == this.Length)
                         {
-                            this.Append(value.ToString());
+                            this.Add(value.ToString());
                         }
                         else
                         {
-                            this.Append(new string('\0', index - this.Length) + value.ToString());
+                            this.Add(new string('\0', index - this.Length) + value.ToString());
                         }
                     }
                     else if (index >= 0)
@@ -628,7 +715,7 @@ namespace Pchp.Core
 
                 if (chunk.GetType() == typeof(string)) return ((string)chunk)[index];
                 if (chunk.GetType() == typeof(byte[])) return (char)((byte[])chunk)[index];
-                if (chunk.GetType() == typeof(PhpString)) return ((PhpString)chunk)[index];
+                if (chunk.GetType() == typeof(Blob)) return ((Blob)chunk)[index];
                 if (chunk.GetType() == typeof(char[])) return ((char[])chunk)[index];
 
                 throw new ArgumentException(chunk.GetType().ToString());
@@ -645,7 +732,7 @@ namespace Pchp.Core
                     chunk = chars;
                 }
                 else if (chunk.GetType() == typeof(byte[])) ((byte[])chunk)[index] = (byte)ch;
-                else if (chunk.GetType() == typeof(PhpString)) ((PhpString)chunk)[index] = ch;
+                else if (chunk.GetType() == typeof(Blob)) ((Blob)chunk)[index] = ch;
                 else if (chunk.GetType() == typeof(char[])) ((char[])chunk)[index] = ch;
                 else throw new ArgumentException(chunk.GetType().ToString());
             }
@@ -678,10 +765,125 @@ namespace Pchp.Core
 
                 if (chunk.GetType() == typeof(string)) return Convert.ToBoolean((string)chunk);
                 if (chunk.GetType() == typeof(byte[])) return Convert.ToBoolean((byte[])chunk);
-                if (chunk.GetType() == typeof(PhpString)) return ((PhpString)chunk).ToBoolean();
+                if (chunk.GetType() == typeof(Blob)) return ((Blob)chunk).ToBoolean();
                 if (chunk.GetType() == typeof(char[])) return Convert.ToBoolean((char[])chunk);
                 throw new ArgumentException();
             }
+
+            #endregion
+
+            #region IPhpArray
+
+            /// <summary>
+            /// Gets number of items in the collection.
+            /// </summary>
+            int IPhpArray.Count => this.Length;
+
+            /// <summary>
+            /// Gets value at given index.
+            /// Gets <c>void</c> value in case the key is not found.
+            /// </summary>
+            PhpValue IPhpArray.GetItemValue(IntStringKey key)
+            {
+                int index = key.IsInteger ? key.Integer : (int)Convert.StringToLongInteger(key.String);
+
+                return (index >= 0 && index < this.Length)
+                    ? PhpValue.Create(this[index].ToString())
+                    : PhpValue.Create(string.Empty);
+            }
+
+            PhpValue IPhpArray.GetItemValue(PhpValue index)
+            {
+                if (index.TryToIntStringKey(out IntStringKey key))
+                {
+                    return ((IPhpArray)this).GetItemValue(key);
+                }
+
+                return PhpValue.Create(string.Empty);
+            }
+
+            void IPhpArray.SetItemValue(PhpValue index, PhpValue value)
+            {
+                if (index.TryToIntStringKey(out IntStringKey key))
+                {
+                    ((IPhpArray)this).SetItemValue(key, value);
+                }
+                else
+                {
+                    throw new ArgumentException();
+                }
+            }
+
+            /// <summary>
+            /// Sets value at specific index. Value must not be an alias.
+            /// </summary>
+            void IPhpArray.SetItemValue(IntStringKey key, PhpValue value)
+            {
+                int index = key.IsInteger ? key.Integer : (int)Convert.StringToLongInteger(key.String);
+
+                char ch;
+
+                switch (value.TypeCode)
+                {
+                    case PhpTypeCode.Long:
+                        ch = (char)value.Long;
+                        break;
+
+                    case PhpTypeCode.String:
+                        ch = (value.String.Length != 0) ? value.String[0] : '\0';
+                        break;
+
+                    case PhpTypeCode.WritableString:
+                        ch = value.WritableString[0];
+                        break;
+
+                    // TODO: other types
+
+                    default:
+                        throw new NotSupportedException(value.TypeCode.ToString());
+                }
+
+                this[key.Integer] = ch;
+            }
+
+            /// <summary>
+            /// Writes aliased value at given index.
+            /// </summary>
+            void IPhpArray.SetItemAlias(IntStringKey key, PhpAlias alias) { throw new NotSupportedException(); }
+
+            void IPhpArray.SetItemAlias(PhpValue index, PhpAlias alias) { throw new NotSupportedException(); }
+
+            /// <summary>
+            /// Add a value to the end of array.
+            /// Value can be an alias.
+            /// </summary>
+            void IPhpArray.AddValue(PhpValue value) { throw new NotSupportedException(); }
+
+            /// <summary>
+            /// Removes a value matching given key.
+            /// In case the value is not found, the method does nothing.
+            /// </summary>
+            void IPhpArray.RemoveKey(IntStringKey key) { throw new NotSupportedException(); }
+
+            void IPhpArray.RemoveKey(PhpValue index)
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <summary>
+            /// Ensures the item at given index is alias.
+            /// </summary>
+            PhpAlias IPhpArray.EnsureItemAlias(IntStringKey key) { throw new NotSupportedException(); }
+
+            /// <summary>
+            /// Ensures the item at given index is class object.
+            /// </summary>
+            object IPhpArray.EnsureItemObject(IntStringKey key) { throw new NotSupportedException(); }
+
+            /// <summary>
+            /// Ensures the item at given index is array.
+            /// </summary>
+            IPhpArray IPhpArray.EnsureItemArray(IntStringKey key) { throw new NotSupportedException(); }
 
             #endregion
         }
@@ -690,7 +892,12 @@ namespace Pchp.Core
         /// Content of the string, may be shared.
         /// Cannot be <c>null</c>.
         /// </summary>
-        Blob _blob;
+        Blob _blob; // TODO: allow union of "null|string|byte[]|Blob"
+
+        /// <summary>
+        /// Content of the string.
+        /// </summary>
+        internal Blob ContainingBlob => _blob;
 
         /// <summary>
         /// Gets the count of characters and binary characters.
@@ -705,34 +912,39 @@ namespace Pchp.Core
         /// <summary>
         /// Gets value indicating the string is empty.
         /// </summary>
-        public bool IsEmpty => _blob.IsEmpty;
+        public bool IsEmpty => ReferenceEquals(_blob, null) || _blob.IsEmpty;
+
+        /// <summary>
+        /// The value is not initialized.
+        /// </summary>
+        public bool IsDefault => ReferenceEquals(_blob, null);
 
         /// <summary>
         /// Empty immutable string.
         /// </summary>
-        public static readonly PhpString Empty = new PhpString();
+        public static PhpString Empty => default(PhpString);
 
-        #region Construction, Append, DeepCopy
+        #region Construction, DeepCopy
 
-        public PhpString()
+        public PhpString(Blob blob)
         {
-            _blob = Blob.Empty.AddRef();
+            _blob = blob;
         }
 
         public PhpString(PhpString from)
+            : this(from._blob?.AddRef())
         {
-            _blob = from._blob.AddRef();
         }
 
         public PhpString(PhpValue x, Context ctx)
         {
             _blob = new Blob();
-            Append(x, ctx);
+            _blob.Add(x, ctx);
         }
 
         public PhpString(string value)
         {
-            _blob = new Blob(value);
+            _blob = new Blob(value);    // TODO: _blob = string
         }
 
         public PhpString(byte[] value)
@@ -745,39 +957,14 @@ namespace Pchp.Core
             _blob = new Blob(x, y);
         }
 
-        public void Append(string value) => EnsureWritable().Append(value);
-
-        public void Append(PhpString value) => EnsureWritable().Append(value);
-
-        public void Append(byte[] value) => EnsureWritable().Append(value);
-
-        public void Append(PhpValue value, Context ctx)
-        {
-            switch (value.TypeCode)
-            {
-                case PhpTypeCode.String:
-                    Append(value.String);
-                    break;
-
-                case PhpTypeCode.WritableString:
-                    Append(value.WritableString.DeepCopy());
-                    break;
-
-                case PhpTypeCode.Alias:
-                    Append(value.Alias.Value, ctx);
-                    break;
-
-                default:
-                    Append(value.ToStringOrThrow(ctx));
-                    break;
-            }
-        }
-
         public PhpString DeepCopy() => new PhpString(this);
 
         #endregion
 
-        Blob EnsureWritable() => _blob.IsShared ? (_blob = _blob.ReleaseOne()) : _blob;
+        /// <summary>
+        /// Gets mutable access to the string value.
+        /// </summary>
+        public Blob EnsureWritable() => _blob.IsShared ? (_blob = _blob.ReleaseOne()) : _blob;
 
         /// <summary>
         /// Outputs the string content to the context output streams.
@@ -819,121 +1006,6 @@ namespace Pchp.Core
 
         #endregion
 
-        #region IPhpArray
-
-        /// <summary>
-        /// Gets number of items in the collection.
-        /// </summary>
-        int IPhpArray.Count => this.Length;
-
-        /// <summary>
-        /// Gets value at given index.
-        /// Gets <c>void</c> value in case the key is not found.
-        /// </summary>
-        PhpValue IPhpArray.GetItemValue(IntStringKey key)
-        {
-            int index = key.IsInteger ? key.Integer : (int)Convert.StringToLongInteger(key.String);
-
-            return (index >= 0 && index < this.Length)
-                ? PhpValue.Create(this[index].ToString())
-                : PhpValue.Create(string.Empty);
-        }
-
-        PhpValue IPhpArray.GetItemValue(PhpValue index)
-        {
-            if (index.TryToIntStringKey(out IntStringKey key))
-            {
-                return ((IPhpArray)this).GetItemValue(key);
-            }
-
-            return PhpValue.Create(string.Empty);
-        }
-
-        void IPhpArray.SetItemValue(PhpValue index, PhpValue value)
-        {
-            if (index.TryToIntStringKey(out IntStringKey key))
-            {
-                ((IPhpArray)this).SetItemValue(key, value);
-            }
-            else
-            {
-                throw new ArgumentException();
-            }
-        }
-
-        /// <summary>
-        /// Sets value at specific index. Value must not be an alias.
-        /// </summary>
-        void IPhpArray.SetItemValue(IntStringKey key, PhpValue value)
-        {
-            int index = key.IsInteger ? key.Integer : (int)Convert.StringToLongInteger(key.String);
-
-            char ch;
-
-            switch (value.TypeCode)
-            {
-                case PhpTypeCode.Long:
-                    ch = (char)value.Long;
-                    break;
-
-                case PhpTypeCode.String:
-                    ch = (value.String.Length != 0) ? value.String[0] : '\0';
-                    break;
-
-                case PhpTypeCode.WritableString:
-                    ch = value.WritableString[0];
-                    break;
-
-                // TODO: other types
-
-                default:
-                    throw new NotSupportedException(value.TypeCode.ToString());
-            }
-
-            this[key.Integer] = ch;
-        }
-
-        /// <summary>
-        /// Writes aliased value at given index.
-        /// </summary>
-        void IPhpArray.SetItemAlias(IntStringKey key, PhpAlias alias) { throw new NotSupportedException(); }
-
-        void IPhpArray.SetItemAlias(PhpValue index, PhpAlias alias) { throw new NotSupportedException(); }
-
-        /// <summary>
-        /// Add a value to the end of array.
-        /// Value can be an alias.
-        /// </summary>
-        void IPhpArray.AddValue(PhpValue value) { throw new NotSupportedException(); }
-
-        /// <summary>
-        /// Removes a value matching given key.
-        /// In case the value is not found, the method does nothing.
-        /// </summary>
-        void IPhpArray.RemoveKey(IntStringKey key) { throw new NotSupportedException(); }
-
-        void IPhpArray.RemoveKey(PhpValue index)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// Ensures the item at given index is alias.
-        /// </summary>
-        PhpAlias IPhpArray.EnsureItemAlias(IntStringKey key) { throw new NotSupportedException(); }
-
-        /// <summary>
-        /// Ensures the item at given index is class object.
-        /// </summary>
-        object IPhpArray.EnsureItemObject(IntStringKey key) { throw new NotSupportedException(); }
-
-        /// <summary>
-        /// Ensures the item at given index is array.
-        /// </summary>
-        IPhpArray IPhpArray.EnsureItemArray(IntStringKey key) { throw new NotSupportedException(); }
-
-        #endregion
-
         #region this[int]
 
         /// <summary>
@@ -957,13 +1029,23 @@ namespace Pchp.Core
 
         public object Clone() => DeepCopy();
 
+        /// <summary>
+        /// Operator that checks the string is default/uninitialized not containing any value.
+        /// </summary>
+        public static bool IsNull(PhpString value) => value.IsDefault;
+
+        /// <summary>
+        /// Gets instance of blob that is not shared.
+        /// </summary>
+        public static Blob EnsureWritable(PhpString str) => str.EnsureWritable();
+
         public override string ToString() => _blob.ToString(Encoding.UTF8);
 
         public string ToString(Encoding encoding) => _blob.ToString(encoding);
 
         public byte[] ToBytes(Context ctx) => ToBytes(ctx.StringEncoding);
 
-        public byte[] ToBytes(Encoding encoding) => _blob.ToBytes(encoding);
+        public byte[] ToBytes(Encoding encoding) => IsEmpty ? Array.Empty<byte>() : _blob.ToBytes(encoding);
 
         public PhpNumber ToNumber()
         {

--- a/src/Peachpie.Runtime/PhpString.cs
+++ b/src/Peachpie.Runtime/PhpString.cs
@@ -975,7 +975,7 @@ namespace Pchp.Core
 
         #region IPhpConvertible
 
-        public bool ToBoolean() => _blob.ToBoolean();
+        public bool ToBoolean() => _blob != null && _blob.ToBoolean();
 
         public double ToDouble() => Convert.StringToDouble(ToString());
 

--- a/src/Peachpie.Runtime/PhpString.cs
+++ b/src/Peachpie.Runtime/PhpString.cs
@@ -895,11 +895,6 @@ namespace Pchp.Core
         Blob _blob; // TODO: allow union of "null|string|byte[]|Blob"
 
         /// <summary>
-        /// Content of the string.
-        /// </summary>
-        internal Blob ContainingBlob => _blob;
-
-        /// <summary>
         /// Gets the count of characters and binary characters.
         /// </summary>
         public int Length => _blob.Length;
@@ -1044,6 +1039,11 @@ namespace Pchp.Core
         /// For write access, use <see cref="EnsureWritable()"/>.
         /// </summary>
         public static Blob AsArray(PhpString str) => str._blob ?? new Blob();
+
+        /// <summary>
+        /// Wraps the string into <see cref="PhpValue"/>.
+        /// </summary>
+        public PhpValue AsPhpValue(PhpString str) => str.IsEmpty ? PhpValue.Create(string.Empty) : PhpValue.Create(str._blob);
 
         public override string ToString() => _blob.ToString(Encoding.UTF8);
 

--- a/src/Peachpie.Runtime/PhpTypeCode.cs
+++ b/src/Peachpie.Runtime/PhpTypeCode.cs
@@ -49,10 +49,10 @@ namespace Pchp.Core
         /// <summary>
         /// Both Unicode and Binary writable string value. Encapsulates two-byte (UTF16), single-byte (binary) string and string builder.
         /// </summary>
-        WritableString,
+        MutableString,
 
         /// <summary>
-        /// A class type, including <c>NULL</c>, <c>resource</c>, <c>Closure</c> or generic <c>Object</c>.
+        /// A class type, <c>resource</c>, <c>Closure</c> or generic <c>Object</c>. Does not represent <c>NULL</c>.
         /// </summary>
         Object,
 

--- a/src/Peachpie.Runtime/PhpValue.DebuggerTypeProxy.cs
+++ b/src/Peachpie.Runtime/PhpValue.DebuggerTypeProxy.cs
@@ -42,7 +42,7 @@ namespace Pchp.Core
                         case PhpTypeCode.Object: return _value.Object;
                         case PhpTypeCode.PhpArray: return _value.Array;
                         case PhpTypeCode.String: return _value.String;
-                        case PhpTypeCode.WritableString: return _value.WritableString.ToString();
+                        case PhpTypeCode.MutableString: return _value.MutableString.ToString();
                         default: return null;
                     }
                 }

--- a/src/Peachpie.Runtime/PhpValue.TypeTable.cs
+++ b/src/Peachpie.Runtime/PhpValue.TypeTable.cs
@@ -365,9 +365,9 @@ namespace Pchp.Core
 
                 me = PhpValue.Create(arr);
 
-                return arr;
+                return arr.ContainingBlob;
             }
-            public override IPhpArray GetArrayAccess(ref PhpValue me) => new PhpString(me.String);
+            public override IPhpArray GetArrayAccess(ref PhpValue me) => EnsureArray(ref me);
             public override PhpValue GetArrayItem(ref PhpValue me, PhpValue index, bool quiet) => PhpValue.Create(Operators.GetItemValue(me.String, index, quiet));
             public override PhpAlias EnsureItemAlias(ref PhpValue me, PhpValue index, bool quiet) { throw new NotSupportedException(); } // TODO: Err
             public override PhpArray ToArray(ref PhpValue me) => PhpArray.New(me);
@@ -417,9 +417,9 @@ namespace Pchp.Core
                 //return obj;
                 throw new NotImplementedException();
             }
-            public override IPhpArray EnsureArray(ref PhpValue me) => me.WritableString;
-            public override IPhpArray GetArrayAccess(ref PhpValue me) => me.WritableString;
-            public override PhpValue GetArrayItem(ref PhpValue me, PhpValue index, bool quiet) => ((IPhpArray)me.WritableString).GetItemValue(index); // quiet);
+            public override IPhpArray EnsureArray(ref PhpValue me) => me.WritableString.EnsureWritable();
+            public override IPhpArray GetArrayAccess(ref PhpValue me) => me.WritableString.EnsureWritable();
+            public override PhpValue GetArrayItem(ref PhpValue me, PhpValue index, bool quiet) => ((IPhpArray)me.WritableString.ContainingBlob).GetItemValue(index); // quiet);
             public override PhpAlias EnsureItemAlias(ref PhpValue me, PhpValue index, bool quiet) { throw new NotSupportedException(); } // TODO: Err
             public override PhpValue DeepCopy(ref PhpValue me) => PhpValue.Create(me.WritableString.DeepCopy());
             public override PhpArray ToArray(ref PhpValue me) => me.WritableString.ToArray();

--- a/src/Peachpie.Runtime/PhpValue.TypeTable.cs
+++ b/src/Peachpie.Runtime/PhpValue.TypeTable.cs
@@ -417,8 +417,8 @@ namespace Pchp.Core
                 //return obj;
                 throw new NotImplementedException();
             }
-            public override IPhpArray EnsureArray(ref PhpValue me) => me.WritableString.EnsureWritable();
-            public override IPhpArray GetArrayAccess(ref PhpValue me) => me.WritableString.EnsureWritable();
+            public override IPhpArray EnsureArray(ref PhpValue me) => (IPhpArray)(me._obj.Obj = me.WritableString.EnsureWritable());
+            public override IPhpArray GetArrayAccess(ref PhpValue me) => me.StringBlob;
             public override PhpValue GetArrayItem(ref PhpValue me, PhpValue index, bool quiet) => ((IPhpArray)me.WritableString.ContainingBlob).GetItemValue(index); // quiet);
             public override PhpAlias EnsureItemAlias(ref PhpValue me, PhpValue index, bool quiet) { throw new NotSupportedException(); } // TODO: Err
             public override PhpValue DeepCopy(ref PhpValue me) => PhpValue.Create(me.WritableString.DeepCopy());

--- a/src/Peachpie.Runtime/PhpValue.TypeTable.cs
+++ b/src/Peachpie.Runtime/PhpValue.TypeTable.cs
@@ -24,7 +24,7 @@ namespace Pchp.Core
             public static readonly DoubleTable DoubleTable = new DoubleTable();
             public static readonly BoolTable BoolTable = new BoolTable();
             public static readonly StringTable StringTable = new StringTable();
-            public static readonly TypeTable WritableStringTable = new WritableStringTable();
+            public static readonly TypeTable MutableStringTable = new MutableStringTable();
             public static readonly ClassTable ClassTable = new ClassTable();
             public static readonly ArrayTable ArrayTable = new ArrayTable();
             public static readonly AliasTable AliasTable = new AliasTable();
@@ -341,8 +341,8 @@ namespace Pchp.Core
                 if (right.TypeCode == PhpTypeCode.String)
                     return right.String == me.String;
 
-                if (right.TypeCode == PhpTypeCode.WritableString)
-                    return right.WritableString.ToString() == me.String;
+                if (right.TypeCode == PhpTypeCode.MutableString)
+                    return right.MutableString.ToString() == me.String;
 
                 if (right.TypeCode == PhpTypeCode.Alias)
                     return StrictEquals(ref me, right.Alias.Value);
@@ -380,28 +380,28 @@ namespace Pchp.Core
         }
 
         [DebuggerNonUserCode]
-        sealed class WritableStringTable : TypeTable
+        sealed class MutableStringTable : TypeTable
         {
-            public override PhpTypeCode Type => PhpTypeCode.WritableString;
+            public override PhpTypeCode Type => PhpTypeCode.MutableString;
             public override bool IsNull(ref PhpValue me) => false;
             public override object ToClass(ref PhpValue me) => new stdClass(DeepCopy(ref me));	// new stdClass(){ $scalar = VALUE }
-            public override string ToStringQuiet(ref PhpValue me) => me.WritableString.ToString();
-            public override string ToString(ref PhpValue me, Context ctx) => me.WritableString.ToString(ctx);
-            public override string ToStringOrThrow(ref PhpValue me, Context ctx) => me.WritableString.ToStringOrThrow(ctx);
-            public override long ToLong(ref PhpValue me) => me.WritableString.ToLong();
-            public override double ToDouble(ref PhpValue me) => me.WritableString.ToDouble();
-            public override bool ToBoolean(ref PhpValue me) => me.WritableString.ToBoolean();
-            public override Convert.NumberInfo ToNumber(ref PhpValue me, out PhpNumber number) => me.WritableString.ToNumber(out number);
-            public override bool TryToIntStringKey(ref PhpValue me, out IntStringKey key) { key = Core.Convert.StringToArrayKey(me.WritableString.ToString()); return true; }
+            public override string ToStringQuiet(ref PhpValue me) => me.MutableString.ToString();
+            public override string ToString(ref PhpValue me, Context ctx) => me.MutableString.ToString(ctx);
+            public override string ToStringOrThrow(ref PhpValue me, Context ctx) => me.MutableString.ToStringOrThrow(ctx);
+            public override long ToLong(ref PhpValue me) => me.MutableString.ToLong();
+            public override double ToDouble(ref PhpValue me) => me.MutableString.ToDouble();
+            public override bool ToBoolean(ref PhpValue me) => me.MutableString.ToBoolean();
+            public override Convert.NumberInfo ToNumber(ref PhpValue me, out PhpNumber number) => me.MutableString.ToNumber(out number);
+            public override bool TryToIntStringKey(ref PhpValue me, out IntStringKey key) { key = Core.Convert.StringToArrayKey(me.MutableString.ToString()); return true; }
             public override IPhpEnumerator GetForeachEnumerator(ref PhpValue me, bool aliasedValues, RuntimeTypeHandle caller) => Operators.GetEmptyForeachEnumerator();
-            public override int Compare(ref PhpValue me, PhpValue right) => Comparison.Compare(me.WritableString.ToString(), right);
+            public override int Compare(ref PhpValue me, PhpValue right) => Comparison.Compare(me.MutableString.ToString(), right);
             public override bool StrictEquals(ref PhpValue me, PhpValue right)
             {
                 if (right.TypeCode == PhpTypeCode.String)
-                    return right.String == me.WritableString.ToString();
+                    return right.String == me.MutableString.ToString();
 
-                if (right.TypeCode == PhpTypeCode.WritableString)
-                    return right.WritableString.ToString() == me.WritableString.ToString();
+                if (right.TypeCode == PhpTypeCode.MutableString)
+                    return right.MutableString.ToString() == me.MutableString.ToString();
 
                 if (right.TypeCode == PhpTypeCode.Alias)
                     return StrictEquals(ref me, right.Alias.Value);
@@ -411,7 +411,7 @@ namespace Pchp.Core
             public override object EnsureObject(ref PhpValue me)
             {
                 //var obj = PhpValue.Create(new stdClass(ctx));
-                //if (me.WritableString.IsEmpty)
+                //if (me.MutableString.IsEmpty)
                 //{
                 //    // me is changed if value is empty
                 //    me = obj;
@@ -419,16 +419,16 @@ namespace Pchp.Core
                 //return obj;
                 throw new NotImplementedException();
             }
-            public override IPhpArray EnsureArray(ref PhpValue me) => (IPhpArray)(me._obj.Obj = me.WritableString.EnsureWritable());
-            public override IPhpArray GetArrayAccess(ref PhpValue me) => me.StringBlob;
-            public override PhpValue GetArrayItem(ref PhpValue me, PhpValue index, bool quiet) => ((IPhpArray)me.StringBlob).GetItemValue(index); // quiet);
+            public override IPhpArray EnsureArray(ref PhpValue me) => (IPhpArray)(me._obj.Obj = me.MutableString.EnsureWritable());
+            public override IPhpArray GetArrayAccess(ref PhpValue me) => me.MutableStringBlob;
+            public override PhpValue GetArrayItem(ref PhpValue me, PhpValue index, bool quiet) => ((IPhpArray)me.MutableStringBlob).GetItemValue(index); // quiet);
             public override PhpAlias EnsureItemAlias(ref PhpValue me, PhpValue index, bool quiet) { throw new NotSupportedException(); } // TODO: Err
-            public override PhpValue DeepCopy(ref PhpValue me) => PhpValue.Create(me.WritableString.DeepCopy());
-            public override PhpArray ToArray(ref PhpValue me) => me.WritableString.ToArray();
-            public override IPhpCallable AsCallable(ref PhpValue me, RuntimeTypeHandle callerCtx) => PhpCallback.Create(me.WritableString.ToString(), callerCtx);
-            public override string DisplayString(ref PhpValue me) => $"'{me.WritableString.ToString()}'";
-            public override void Output(ref PhpValue me, Context ctx) => me.WritableString.Output(ctx);
-            public override void Accept(ref PhpValue me, PhpVariableVisitor visitor) => visitor.Accept(me.WritableString);
+            public override PhpValue DeepCopy(ref PhpValue me) => PhpValue.Create(me.MutableString.DeepCopy());
+            public override PhpArray ToArray(ref PhpValue me) => me.MutableString.ToArray();
+            public override IPhpCallable AsCallable(ref PhpValue me, RuntimeTypeHandle callerCtx) => PhpCallback.Create(me.MutableString.ToString(), callerCtx);
+            public override string DisplayString(ref PhpValue me) => $"'{me.MutableString.ToString()}'";
+            public override void Output(ref PhpValue me, Context ctx) => me.MutableString.Output(ctx);
+            public override void Accept(ref PhpValue me, PhpVariableVisitor visitor) => visitor.Accept(me.MutableString);
         }
 
         [DebuggerNonUserCode]

--- a/src/Peachpie.Runtime/PhpValue.TypeTable.cs
+++ b/src/Peachpie.Runtime/PhpValue.TypeTable.cs
@@ -361,11 +361,13 @@ namespace Pchp.Core
             }
             public override IPhpArray EnsureArray(ref PhpValue me)
             {
-                var arr = new PhpString(me.String);
+                var str = new PhpString(me.String); // upgrade to mutable string
+                var arr = str.EnsureWritable();     // ensure its internal blob
 
-                me = PhpValue.Create(arr);
+                me = PhpValue.Create(str);          // copy back new value
 
-                return arr.ContainingBlob;
+                //
+                return arr;
             }
             public override IPhpArray GetArrayAccess(ref PhpValue me) => EnsureArray(ref me);
             public override PhpValue GetArrayItem(ref PhpValue me, PhpValue index, bool quiet) => PhpValue.Create(Operators.GetItemValue(me.String, index, quiet));
@@ -419,7 +421,7 @@ namespace Pchp.Core
             }
             public override IPhpArray EnsureArray(ref PhpValue me) => (IPhpArray)(me._obj.Obj = me.WritableString.EnsureWritable());
             public override IPhpArray GetArrayAccess(ref PhpValue me) => me.StringBlob;
-            public override PhpValue GetArrayItem(ref PhpValue me, PhpValue index, bool quiet) => ((IPhpArray)me.WritableString.ContainingBlob).GetItemValue(index); // quiet);
+            public override PhpValue GetArrayItem(ref PhpValue me, PhpValue index, bool quiet) => ((IPhpArray)me.StringBlob).GetItemValue(index); // quiet);
             public override PhpAlias EnsureItemAlias(ref PhpValue me, PhpValue index, bool quiet) { throw new NotSupportedException(); } // TODO: Err
             public override PhpValue DeepCopy(ref PhpValue me) => PhpValue.Create(me.WritableString.DeepCopy());
             public override PhpArray ToArray(ref PhpValue me) => me.WritableString.ToArray();

--- a/src/Peachpie.Runtime/PhpValue.cs
+++ b/src/Peachpie.Runtime/PhpValue.cs
@@ -553,6 +553,13 @@ namespace Pchp.Core
             _obj.Obj = obj;
         }
 
+        private PhpValue(PhpString.Blob blob) : this()
+        {
+            Debug.Assert(blob != null);
+            _type = TypeTable.WritableStringTable;
+            _obj.Obj = blob;
+        }
+
         private PhpValue(TypeTable type) : this()
         {
             _type = type;
@@ -574,7 +581,9 @@ namespace Pchp.Core
 
         public static PhpValue Create(string value) => new PhpValue(TypeTable.StringTable, value);
 
-        public static PhpValue Create(PhpString value) => value.IsEmpty ? new PhpValue(TypeTable.StringTable, string.Empty) : new PhpValue(TypeTable.WritableStringTable, value.ContainingBlob);
+        public static PhpValue Create(PhpString value) => value.AsPhpValue(value);
+
+        internal static PhpValue Create(PhpString.Blob blob) => new PhpValue(blob);
 
         public static PhpValue Create(PhpArray value) => new PhpValue(TypeTable.ArrayTable, value);
 

--- a/src/Peachpie.Runtime/PhpValue.cs
+++ b/src/Peachpie.Runtime/PhpValue.cs
@@ -176,7 +176,7 @@ namespace Pchp.Core
         /// Gets the object field of the value as PHP writable string.
         /// Does not perform a conversion, expects the value is of type (writable UTF16 or single-byte) string.
         /// </summary>
-        public PhpString WritableString { get { Debug.Assert(_obj.Obj is PhpString); return (PhpString)_obj.Obj; } }
+        public PhpString WritableString { get { Debug.Assert(_obj.Obj is PhpString.Blob); return new PhpString((PhpString.Blob)_obj.Obj); } }
 
         /// <summary>
         /// Gets underlaying reference object.
@@ -569,7 +569,7 @@ namespace Pchp.Core
 
         public static PhpValue Create(string value) => new PhpValue(TypeTable.StringTable, value);
 
-        public static PhpValue Create(PhpString value) => new PhpValue(TypeTable.WritableStringTable, value);
+        public static PhpValue Create(PhpString value) => value.IsEmpty ? new PhpValue(TypeTable.StringTable, string.Empty) : new PhpValue(TypeTable.WritableStringTable, value.ContainingBlob);
 
         public static PhpValue Create(PhpArray value) => new PhpValue(TypeTable.ArrayTable, value);
 

--- a/src/Peachpie.Runtime/PhpValue.cs
+++ b/src/Peachpie.Runtime/PhpValue.cs
@@ -132,7 +132,7 @@ namespace Pchp.Core
                     case PhpTypeCode.Long:
                     case PhpTypeCode.Double:
                     case PhpTypeCode.String:
-                    case PhpTypeCode.WritableString:
+                    case PhpTypeCode.MutableString:
                     case PhpTypeCode.Null:
                         return true;
 
@@ -175,13 +175,13 @@ namespace Pchp.Core
         /// <summary>
         /// Gets underlaying <see cref="PhpString.Blob"/> object.
         /// </summary>
-        internal PhpString.Blob StringBlob { get { Debug.Assert(_obj.Obj is PhpString.Blob); return (PhpString.Blob)_obj.Obj; } }
+        internal PhpString.Blob MutableStringBlob { get { Debug.Assert(_obj.Obj is PhpString.Blob); return (PhpString.Blob)_obj.Obj; } }
 
         /// <summary>
         /// Gets the object field of the value as PHP writable string.
         /// Does not perform a conversion, expects the value is of type (writable UTF16 or single-byte) string.
         /// </summary>
-        public PhpString WritableString { get { return new PhpString(StringBlob); } }
+        public PhpString MutableString { get { return new PhpString(MutableStringBlob); } }
 
         /// <summary>
         /// Gets underlaying reference object.
@@ -442,7 +442,7 @@ namespace Pchp.Core
                 case PhpTypeCode.Object: return Object;
                 case PhpTypeCode.PhpArray: return Array;
                 case PhpTypeCode.String: return String;
-                case PhpTypeCode.WritableString: return WritableString.ToString();
+                case PhpTypeCode.MutableString: return MutableString.ToString();
                 case PhpTypeCode.Alias: return Alias.Value.ToClr();
                 default:
                     throw new ArgumentException();
@@ -556,7 +556,7 @@ namespace Pchp.Core
         private PhpValue(PhpString.Blob blob) : this()
         {
             Debug.Assert(blob != null);
-            _type = TypeTable.WritableStringTable;
+            _type = TypeTable.MutableStringTable;
             _obj.Obj = blob;
         }
 

--- a/src/Peachpie.Runtime/PhpValue.cs
+++ b/src/Peachpie.Runtime/PhpValue.cs
@@ -173,10 +173,15 @@ namespace Pchp.Core
         public string String { get { Debug.Assert(_obj.Obj is string || _obj.Obj == null); return _obj.String; } }
 
         /// <summary>
+        /// Gets underlaying <see cref="PhpString.Blob"/> object.
+        /// </summary>
+        internal PhpString.Blob StringBlob { get { Debug.Assert(_obj.Obj is PhpString.Blob); return (PhpString.Blob)_obj.Obj; } }
+
+        /// <summary>
         /// Gets the object field of the value as PHP writable string.
         /// Does not perform a conversion, expects the value is of type (writable UTF16 or single-byte) string.
         /// </summary>
-        public PhpString WritableString { get { Debug.Assert(_obj.Obj is PhpString.Blob); return new PhpString((PhpString.Blob)_obj.Obj); } }
+        public PhpString WritableString { get { return new PhpString(StringBlob); } }
 
         /// <summary>
         /// Gets underlaying reference object.

--- a/src/Peachpie.Runtime/Variables.cs
+++ b/src/Peachpie.Runtime/Variables.cs
@@ -463,7 +463,7 @@ namespace Pchp.Core
         /// </summary>
         public static byte[] AsBytesOrNull(this PhpValue value, Context ctx)
         {
-            var phpstr = (value.IsAlias ? value.Alias.Value.Object : value.Object) as PhpString;
+            var phpstr = (value.IsAlias ? value.Alias.Value.Object : value.Object) as PhpString.Blob;
             return (phpstr != null && phpstr.ContainsBinaryData)
                 ? phpstr.ToBytes(ctx)
                 : null;

--- a/src/Peachpie.Runtime/Variables.cs
+++ b/src/Peachpie.Runtime/Variables.cs
@@ -268,7 +268,7 @@ namespace Pchp.Core
                 case PhpTypeCode.Double: return TypeNameDouble;
                 case PhpTypeCode.Boolean: return TypeNameBoolean;
                 case PhpTypeCode.String:
-                case PhpTypeCode.WritableString: return TypeNameString;
+                case PhpTypeCode.MutableString: return TypeNameString;
                 case PhpTypeCode.Alias: return GetTypeName(value.Alias.Value);
                 case PhpTypeCode.PhpArray: return PhpArray.PhpTypeName;
                 case PhpTypeCode.Object:
@@ -426,7 +426,7 @@ namespace Pchp.Core
             switch (value.TypeCode)
             {
                 case PhpTypeCode.String: return value.String;
-                case PhpTypeCode.WritableString: return value.WritableString.ToString();
+                case PhpTypeCode.MutableString: return value.MutableString.ToString();
                 case PhpTypeCode.Alias: return ToStringOrNull(value.Alias.Value);
                 default: return null;
             }
@@ -442,7 +442,7 @@ namespace Pchp.Core
             switch (value.TypeCode)
             {
                 case PhpTypeCode.String: return Encoding.UTF8.GetBytes(value.String);
-                case PhpTypeCode.WritableString: return value.WritableString.ToBytes(Encoding.UTF8);
+                case PhpTypeCode.MutableString: return value.MutableString.ToBytes(Encoding.UTF8);
                 case PhpTypeCode.Alias: return ToBytesOrNull(value.Alias.Value);
                 default: return null;
             }
@@ -452,7 +452,7 @@ namespace Pchp.Core
         {
             switch (value.TypeCode)
             {
-                case PhpTypeCode.WritableString: return value.WritableString.ToBytes(ctx);
+                case PhpTypeCode.MutableString: return value.MutableString.ToBytes(ctx);
                 case PhpTypeCode.Alias: return ToBytes(value.Alias.Value, ctx);
                 default: return ctx.StringEncoding.GetBytes(value.ToString(ctx));
             }


### PR DESCRIPTION
Upgrades PhpString (combining byte[] and UTF16 strings) implementation as a value type, this allows us to use PhpString more frequently without sacrificing performance

Additionally in future this struct will be able to hold String or byte[] without a single allocation.