### PR TITLE
heavy multi-threading can cause an invalid index exception in the c# …

### DIFF
--- a/src/Peachpie.Runtime/Context.cs
+++ b/src/Peachpie.Runtime/Context.cs
@@ -487,7 +487,7 @@ namespace Pchp.Core
         #region Resources // objects that need dispose
 
         HashSet<IDisposable> _lazyDisposables = null;
-        private string disposeLock = "";
+        private object disposeLock = new object();
 
         public void RegisterDisposable(IDisposable obj)
         {
@@ -513,7 +513,7 @@ namespace Pchp.Core
             }
         }
 
-        private string setlock = "";
+        private object setlock = new object();
         void ProcessDisposables()
         {
             HashSet<IDisposable> set = null;

--- a/src/Peachpie.Runtime/Context.cs
+++ b/src/Peachpie.Runtime/Context.cs
@@ -487,39 +487,53 @@ namespace Pchp.Core
         #region Resources // objects that need dispose
 
         HashSet<IDisposable> _lazyDisposables = null;
+        private string disposeLock = "";
 
         public void RegisterDisposable(IDisposable obj)
         {
-            if (_lazyDisposables == null)
+            lock (disposeLock)
             {
-                _lazyDisposables = new HashSet<IDisposable>();
-            }
-
-            string tolock= "";
-            lock (tolock)
-            {
+                if (_lazyDisposables == null)
+                {
+                    _lazyDisposables = new HashSet<IDisposable>();
+                }
+ 
                 _lazyDisposables.Add(obj);
             }
         }
 
         public void UnregisterDisposable(IDisposable obj)
         {
-            if (_lazyDisposables != null)
+            lock (disposeLock)
             {
-                _lazyDisposables.Remove(obj);
+                if (_lazyDisposables != null)
+                {
+                    _lazyDisposables.Remove(obj);
+                }
             }
         }
 
+        private string setlock = "";
         void ProcessDisposables()
         {
-            var set = _lazyDisposables;
-            if (set != null && set.Count != 0)
+            HashSet<IDisposable> set = null;
+            lock (setlock)
             {
-                _lazyDisposables = null;
-
-                foreach (var x in set)
+                lock (disposeLock)
                 {
-                    x.Dispose();
+                    set = _lazyDisposables;
+                    if (set != null && set.Count != 0)
+                    {
+                        _lazyDisposables = null;
+                    }
+                }
+
+                if (set != null && set.Count != 0)
+                {
+                    foreach (var x in set)
+                    {
+                        x.Dispose();
+                    }
                 }
             }
         }

--- a/src/Peachpie.Runtime/Context.cs
+++ b/src/Peachpie.Runtime/Context.cs
@@ -495,7 +495,11 @@ namespace Pchp.Core
                 _lazyDisposables = new HashSet<IDisposable>();
             }
 
-            _lazyDisposables.Add(obj);
+            string tolock= "";
+            lock (tolock)
+            {
+                _lazyDisposables.Add(obj);
+            }
         }
 
         public void UnregisterDisposable(IDisposable obj)


### PR DESCRIPTION
…runtime
While I was trying to make a simple test to replicate getting duplicate resource ids, I discovered that I was getting an invalid or negative index in a c# module. I don't know that the lock I used is the best fix, but it does solve this problem.