### PR TITLE
Cross target libraries to .NETSTANDARD 2.0

### DIFF
--- a/src/Compiler/peach/peach.csproj
+++ b/src/Compiler/peach/peach.csproj
@@ -23,9 +23,4 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
 </Project>

--- a/src/Compiler/peach/peach.csproj
+++ b/src/Compiler/peach/peach.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Compiler/peach/peach.csproj
+++ b/src/Compiler/peach/peach.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <AssemblyName>peach</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>peach</PackageId>

--- a/src/PDO/Peachpie.Library.PDO.Firebird/Peachpie.Library.PDO.Firebird.csproj
+++ b/src/PDO/Peachpie.Library.PDO.Firebird/Peachpie.Library.PDO.Firebird.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.Firebird</AssemblyName>
     <PackageId>Peachpie.Library.PDO.Firebird</PackageId>
@@ -15,11 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/src/PDO/Peachpie.Library.PDO.Firebird/Peachpie.Library.PDO.Firebird.csproj
+++ b/src/PDO/Peachpie.Library.PDO.Firebird/Peachpie.Library.PDO.Firebird.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.Firebird</AssemblyName>
     <PackageId>Peachpie.Library.PDO.Firebird</PackageId>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.0" />
+    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="5.12.1" />
   </ItemGroup>
 
 </Project>

--- a/src/PDO/Peachpie.Library.PDO.IBM/PDODB2Driver.cs
+++ b/src/PDO/Peachpie.Library.PDO.IBM/PDODB2Driver.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Pchp.Core;
 
 namespace Peachpie.Library.PDO
 {
     //IBM pure ADO.NET Driver is not available on dotnet core, only on framework
-#if NETSTANDARD1_6
-using IBM.Data.DB2.Core;
- 
+    using IBM.Data.DB2.Core;
+
     /// <summary>
     /// PDO driver class for IBM DB2
     /// </summary>
@@ -53,5 +49,4 @@ using IBM.Data.DB2.Core;
             }
         }
     }
-#endif
 }

--- a/src/PDO/Peachpie.Library.PDO.IBM/Peachpie.Library.PDO.IBM.csproj
+++ b/src/PDO/Peachpie.Library.PDO.IBM/Peachpie.Library.PDO.IBM.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.IBM</AssemblyName>
     <PackageId>Peachpie.Library.PDO.IBM</PackageId>
@@ -11,7 +11,7 @@
 
   <PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
-	<Platform>x64</Platform>
+    <Platform>x64</Platform>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\Peachpie.Library.PDO\Peachpie.Library.PDO.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup>
     <PackageReference Include="IBM.Data.DB2.Core" Version="1.1.1.101" />
   </ItemGroup>
 

--- a/src/PDO/Peachpie.Library.PDO.IBM/Peachpie.Library.PDO.IBM.csproj
+++ b/src/PDO/Peachpie.Library.PDO.IBM/Peachpie.Library.PDO.IBM.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.IBM</AssemblyName>
     <PackageId>Peachpie.Library.PDO.IBM</PackageId>
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IBM.Data.DB2.Core" Version="1.1.1.101" />
+    <PackageReference Include="IBM.Data.DB2.Core" Version="1.2.2.100" />
   </ItemGroup>
 
 </Project>

--- a/src/PDO/Peachpie.Library.PDO.MySQL/PDOMySQLDriver.cs
+++ b/src/PDO/Peachpie.Library.PDO.MySQL/PDOMySQLDriver.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using MySql.Data.MySqlClient;
+﻿using MySql.Data.MySqlClient;
+
 using Pchp.Core;
-using System.Data.Common;
 
 namespace Peachpie.Library.PDO.MySQL
 {
@@ -27,9 +23,11 @@ namespace Peachpie.Library.PDO.MySQL
         protected override string BuildConnectionString(string dsn, string user, string password, PhpArray options)
         {
             //TODO mysql pdo parameters to dotnet connectionstring
-            var csb = new MySqlConnectionStringBuilder(dsn);
-            csb.UserID = user;
-            csb.Password = password;
+            var csb = new MySqlConnectionStringBuilder(dsn)
+            {
+                UserID = user,
+                Password = password
+            };
             return csb.ConnectionString;
         }
 

--- a/src/PDO/Peachpie.Library.PDO.MySQL/Peachpie.Library.PDO.MySQL.csproj
+++ b/src/PDO/Peachpie.Library.PDO.MySQL/Peachpie.Library.PDO.MySQL.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.MySQL</AssemblyName>
     <PackageId>Peachpie.Library.PDO.MySQL</PackageId>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySql.Data" Version="7.0.6-IR31" />
+    <PackageReference Include="MySqlConnector" Version="0.40.4" />
   </ItemGroup>
 
 </Project>

--- a/src/PDO/Peachpie.Library.PDO.MySQL/Peachpie.Library.PDO.MySQL.csproj
+++ b/src/PDO/Peachpie.Library.PDO.MySQL/Peachpie.Library.PDO.MySQL.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.MySQL</AssemblyName>
     <PackageId>Peachpie.Library.PDO.MySQL</PackageId>

--- a/src/PDO/Peachpie.Library.PDO.MySQL/Peachpie.Library.PDO.MySQL.csproj
+++ b/src/PDO/Peachpie.Library.PDO.MySQL/Peachpie.Library.PDO.MySQL.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.MySQL</AssemblyName>
     <PackageId>Peachpie.Library.PDO.MySQL</PackageId>
@@ -15,11 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="MySql.Data" Version="7.0.6-IR31" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/src/PDO/Peachpie.Library.PDO.PgSQL/Peachpie.Library.PDO.PgSQL.csproj
+++ b/src/PDO/Peachpie.Library.PDO.PgSQL/Peachpie.Library.PDO.PgSQL.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.PgSQL</AssemblyName>
     <PackageId>Peachpie.Library.PDO.PgSQL</PackageId>

--- a/src/PDO/Peachpie.Library.PDO.PgSQL/Peachpie.Library.PDO.PgSQL.csproj
+++ b/src/PDO/Peachpie.Library.PDO.PgSQL/Peachpie.Library.PDO.PgSQL.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.PgSQL</AssemblyName>
     <PackageId>Peachpie.Library.PDO.PgSQL</PackageId>
@@ -15,11 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="3.2.6" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/src/PDO/Peachpie.Library.PDO.PgSQL/Peachpie.Library.PDO.PgSQL.csproj
+++ b/src/PDO/Peachpie.Library.PDO.PgSQL/Peachpie.Library.PDO.PgSQL.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="3.2.6" />
+    <PackageReference Include="Npgsql" Version="3.2.7" />
   </ItemGroup>
 
 </Project>

--- a/src/PDO/Peachpie.Library.PDO.SqlSrv/PDOSqlServerDriver.cs
+++ b/src/PDO/Peachpie.Library.PDO.SqlSrv/PDOSqlServerDriver.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data.Common;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Data.SqlClient;
 using Pchp.Core;
 
 namespace Peachpie.Library.PDO.SqlSrv
@@ -11,7 +6,7 @@ namespace Peachpie.Library.PDO.SqlSrv
     /// <summary>
     /// PDO driver for Microsoft SqlServer
     /// </summary>
-    /// <seealso cref="Peachpie.Library.PDO.PDODriver" />
+    /// <seealso cref="PDODriver" />
     [System.Composition.Export(typeof(IPDODriver))]
     public class PDOSqlServerDriver : PDODriver
     {
@@ -36,9 +31,12 @@ namespace Peachpie.Library.PDO.SqlSrv
         protected override string BuildConnectionString(string dsn, string user, string password, PhpArray options)
         {
             //TODO sqlserver pdo dsn to dotnet connectionstring
-            var csb = new SqlConnectionStringBuilder(dsn);
-            csb.UserID = user;
-            csb.Password = password;
+            var csb = new SqlConnectionStringBuilder(dsn)
+            {
+                UserID = user,
+                Password = password
+            };
+
             return csb.ConnectionString;
         }
     }

--- a/src/PDO/Peachpie.Library.PDO.SqlSrv/Peachpie.Library.PDO.SqlSrv.csproj
+++ b/src/PDO/Peachpie.Library.PDO.SqlSrv/Peachpie.Library.PDO.SqlSrv.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.SqlSrv</AssemblyName>
     <PackageId>Peachpie.Library.PDO.SqlSrv</PackageId>
@@ -13,13 +13,8 @@
     <ProjectReference Include="..\Peachpie.Library.PDO\Peachpie.Library.PDO.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/src/PDO/Peachpie.Library.PDO.SqlSrv/Peachpie.Library.PDO.SqlSrv.csproj
+++ b/src/PDO/Peachpie.Library.PDO.SqlSrv/Peachpie.Library.PDO.SqlSrv.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.SqlSrv</AssemblyName>
     <PackageId>Peachpie.Library.PDO.SqlSrv</PackageId>
@@ -13,8 +13,8 @@
     <ProjectReference Include="..\Peachpie.Library.PDO\Peachpie.Library.PDO.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+  <ItemGroup>
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
   </ItemGroup>
 
 </Project>

--- a/src/PDO/Peachpie.Library.PDO.Sqlite/PDOSqliteDriver.cs
+++ b/src/PDO/Peachpie.Library.PDO.Sqlite/PDOSqliteDriver.cs
@@ -1,22 +1,7 @@
-﻿using System;
-using System.Collections.Specialized;
-using System.Data.Common;
+﻿using System.Collections.Generic;
 using Pchp.Core;
-using System.Collections.Generic;
-
-#if NET46
-using System.Data.SQLite;
-using Factory = System.Data.SQLite.SQLiteFactory;
-using Connection = System.Data.SQLite.SQLiteConnection;
-using ConnectionStringBuilder = System.Data.SQLite.SQLiteConnectionStringBuilder;
-using Command = System.Data.SQLite.SQLiteCommand;
-#else
-using Microsoft.Data.Sqlite;
-using Factory = Microsoft.Data.Sqlite.SqliteFactory;
-using Connection = Microsoft.Data.Sqlite.SqliteConnection;
 using ConnectionStringBuilder = Microsoft.Data.Sqlite.SqliteConnectionStringBuilder;
-using Command = Microsoft.Data.Sqlite.SqliteCommand;
-#endif
+using Factory = Microsoft.Data.Sqlite.SqliteFactory;
 
 namespace Peachpie.Library.PDO.Sqlite
 {
@@ -56,31 +41,17 @@ namespace Peachpie.Library.PDO.Sqlite
 
         private static PhpValue sqliteCreateAggregate(PDO pdo, PhpArray arguments)
         {
-#if NET46
-            throw new NotImplementedException();
-#else
             return PhpValue.False;
-#endif
         }
         private static PhpValue sqliteCreateCollation(PDO pdo, PhpArray arguments)
         {
-#if NET46
-            throw new NotImplementedException();
-#else
             return PhpValue.False;
-#endif
         }
 
         private static PhpValue sqliteCreateFunction(PDO pdo, PhpArray arguments)
         {
-#if NET46
-            throw new NotImplementedException();
-            // From https://github.com/DEVSENSE/Phalanger/blob/master/Source/Extensions/PDOSQLite/SQLitePDODriver.cs
-            // SQLiteFunction.RegisterFunction(func_name, nbr_arg, FunctionType.Scalar, null, d, null);
-#else
             //Microsoft connector does not support CreateFunction
             return PhpValue.False;
-#endif
         }
 
         /// <inheritDoc />

--- a/src/PDO/Peachpie.Library.PDO.Sqlite/Peachpie.Library.PDO.Sqlite.csproj
+++ b/src/PDO/Peachpie.Library.PDO.Sqlite/Peachpie.Library.PDO.Sqlite.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.Sqlite</AssemblyName>
     <PackageId>Peachpie.Library.PDO.Sqlite</PackageId>
@@ -13,12 +13,8 @@
     <ProjectReference Include="..\Peachpie.Library.PDO\Peachpie.Library.PDO.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="1.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <PackageReference Include="System.Data.SQLite" Version="1.0.106" />
   </ItemGroup>
 
 </Project>

--- a/src/PDO/Peachpie.Library.PDO.Sqlite/Peachpie.Library.PDO.Sqlite.csproj
+++ b/src/PDO/Peachpie.Library.PDO.Sqlite/Peachpie.Library.PDO.Sqlite.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Peachpie.Library.PDO.Sqlite</AssemblyName>
     <PackageId>Peachpie.Library.PDO.Sqlite</PackageId>
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\Peachpie.Library.PDO\Peachpie.Library.PDO.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
     <PackageReference Include="Microsoft.Data.Sqlite" Version="1.1.0" />
   </ItemGroup>
 

--- a/src/PDO/Peachpie.Library.PDO/Peachpie.Library.PDO.csproj
+++ b/src/PDO/Peachpie.Library.PDO/Peachpie.Library.PDO.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Peachpie.Library.PDO</AssemblyName>
     <PackageId>Peachpie.Library.PDO</PackageId>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -11,10 +11,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Peachpie.Library\Peachpie.Library.csproj" />
     <ProjectReference Include="..\..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/PDO/Peachpie.Library.PDO/Peachpie.Library.PDO.csproj
+++ b/src/PDO/Peachpie.Library.PDO/Peachpie.Library.PDO.csproj
@@ -2,10 +2,10 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Peachpie.Library.PDO</AssemblyName>
     <PackageId>Peachpie.Library.PDO</PackageId>
-	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,11 +15,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/src/Peachpie.App/Peachpie.App.csproj
+++ b/src/Peachpie.App/Peachpie.App.csproj
@@ -8,14 +8,14 @@
     <PackageId>Peachpie.App</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\PDO\Peachpie.Library.PDO\Peachpie.Library.PDO.csproj" />
     <ProjectReference Include="..\Peachpie.Library.Scripting\Peachpie.Library.Scripting.csproj" />
     <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
-	<ProjectReference Include="..\Peachpie.Library\Peachpie.Library.csproj" />
+    <ProjectReference Include="..\Peachpie.Library\Peachpie.Library.csproj" />
     <ProjectReference Include="..\Peachpie.Library.MsSql\Peachpie.Library.MsSql.csproj" />
   </ItemGroup>
 

--- a/src/Peachpie.App/Peachpie.App.csproj
+++ b/src/Peachpie.App/Peachpie.App.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
     <Description>Peachpie platform dependencies.</Description>
-    <TargetFrameworks>netstandard1.5;netstandard1.6;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Peachpie.App</AssemblyName>
     <PackageId>Peachpie.App</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -17,15 +17,7 @@
     <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
     <ProjectReference Include="..\Peachpie.Library\Peachpie.Library.csproj" />
     <ProjectReference Include="..\Peachpie.Library.MsSql\Peachpie.Library.MsSql.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.5' ">
     <ProjectReference Include="..\Peachpie.Library.MySql\Peachpie.Library.MySql.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net46' ">

--- a/src/Peachpie.App/Peachpie.App.csproj
+++ b/src/Peachpie.App/Peachpie.App.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
     <Description>Peachpie platform dependencies.</Description>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Peachpie.App</AssemblyName>
     <PackageId>Peachpie.App</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -18,9 +18,6 @@
     <ProjectReference Include="..\Peachpie.Library\Peachpie.Library.csproj" />
     <ProjectReference Include="..\Peachpie.Library.MsSql\Peachpie.Library.MsSql.csproj" />
     <ProjectReference Include="..\Peachpie.Library.MySql\Peachpie.Library.MySql.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net46' ">
     <ProjectReference Include="..\Peachpie.Library.XmlDom\Peachpie.Library.XmlDom.csproj" />
   </ItemGroup>
 

--- a/src/Peachpie.CodeAnalysis/Peachpie.CodeAnalysis.csproj
+++ b/src/Peachpie.CodeAnalysis/Peachpie.CodeAnalysis.csproj
@@ -19,11 +19,6 @@
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
   </ItemGroup>

--- a/src/Peachpie.CodeAnalysis/Peachpie.CodeAnalysis.csproj
+++ b/src/Peachpie.CodeAnalysis/Peachpie.CodeAnalysis.csproj
@@ -15,8 +15,13 @@
   <ItemGroup>
     <PackageReference Include="Devsense.Php.Parser" Version="1.4.48" />
     <PackageReference Include="Peachpie.Microsoft.CodeAnalysis" Version="0.6.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
+    
+    <!-- Prevent package downgrades -->
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />  
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">

--- a/src/Peachpie.CodeAnalysis/Peachpie.CodeAnalysis.csproj
+++ b/src/Peachpie.CodeAnalysis/Peachpie.CodeAnalysis.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Peachpie.CodeAnalysis</AssemblyName>
     <AssemblyOriginatorKeyFile>../../build/StrongKeys/core.snk</AssemblyOriginatorKeyFile>
@@ -19,13 +19,14 @@
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
     
     <!-- Prevent package downgrades -->
+    <PackageReference Include="System.Collections" Version="4.3.0" />  
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />  
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />  
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />  
     <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />  
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />  
   </ItemGroup>
 
 </Project>

--- a/src/Peachpie.Compiler.Tools/Peachpie.Compiler.Tools.csproj
+++ b/src/Peachpie.Compiler.Tools/Peachpie.Compiler.Tools.csproj
@@ -22,9 +22,4 @@
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />    
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
 </Project>

--- a/src/Peachpie.Compiler.Tools/Peachpie.Compiler.Tools.csproj
+++ b/src/Peachpie.Compiler.Tools/Peachpie.Compiler.Tools.csproj
@@ -3,14 +3,11 @@
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
     <Description>Command line tool enabling 'php' project compilation.</Description>
-    <TargetFrameworks>net46;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>dotnet-compile-php</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Peachpie.Compiler.Tools</PackageId>
     <PackageTags>dotnet;compile-php</PackageTags>
-    <!-- PostBuildEvent Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-	powershell -File ../../../../../build/update-cache.ps1 $(VersionPrefix) $(VersionSuffix)
-	</PostBuildEvent -->
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/Peachpie.Library.Graphics/Peachpie.Library.Graphics.csproj
+++ b/src/Peachpie.Library.Graphics/Peachpie.Library.Graphics.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;1574</NoWarn>
     <AssemblyName>Peachpie.Library.Graphics</AssemblyName>
     <PackageId>Peachpie.Library.Graphics</PackageId>

--- a/src/Peachpie.Library.Graphics/Peachpie.Library.Graphics.csproj
+++ b/src/Peachpie.Library.Graphics/Peachpie.Library.Graphics.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;1574</NoWarn>
     <AssemblyName>Peachpie.Library.Graphics</AssemblyName>
     <PackageId>Peachpie.Library.Graphics</PackageId>

--- a/src/Peachpie.Library.MsSql/Peachpie.Library.MsSql.csproj
+++ b/src/Peachpie.Library.MsSql/Peachpie.Library.MsSql.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Peachpie.Library.MsSql</AssemblyName>
     <PackageId>Peachpie.Library.MsSql</PackageId>
     <PackageTags>peachpie;library;mssql</PackageTags>
@@ -15,13 +15,8 @@
     <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/src/Peachpie.Library.MsSql/Peachpie.Library.MsSql.csproj
+++ b/src/Peachpie.Library.MsSql/Peachpie.Library.MsSql.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Peachpie.Library.MsSql</AssemblyName>
     <PackageId>Peachpie.Library.MsSql</PackageId>
     <PackageTags>peachpie;library;mssql</PackageTags>
@@ -15,8 +15,8 @@
     <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+  <ItemGroup>
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Peachpie.Library.MySql/MySqlConnectionResource.cs
+++ b/src/Peachpie.Library.MySql/MySqlConnectionResource.cs
@@ -48,7 +48,7 @@ namespace Peachpie.Library.MySql
             var myreader = (MySqlDataReader)_pendingReader;
             if (myreader != null)
             {
-                myreader.Close();   // we have to call Close() on MySqlDataReader, it is declared as non-virtual!
+                myreader.Dispose();
                 _pendingReader = myreader = null;
             }
         }

--- a/src/Peachpie.Library.MySql/MySqlResultResource.cs
+++ b/src/Peachpie.Library.MySql/MySqlResultResource.cs
@@ -1,13 +1,10 @@
-﻿using MySql.Data.MySqlClient;
-using MySql.Data.Types;
-using Pchp.Core;
-using Pchp.Library.Database;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
+using Pchp.Core;
+using Pchp.Library.Database;
 using Pchp.Library.Resources;
 
 namespace Peachpie.Library.MySql
@@ -69,10 +66,8 @@ namespace Peachpie.Library.MySql
         protected override void FreeManaged()
         {
             var reader = (MySqlDataReader)this.Reader;
-            if (reader != null)
-            {
-                reader.Close(); // non virtual!!
-            }
+
+            reader?.Dispose();
 
             base.FreeManaged();
         }
@@ -176,8 +171,8 @@ namespace Peachpie.Library.MySql
             if (sqlValue.GetType() == typeof(float))
                 return Pchp.Core.Convert.ToString((float)sqlValue);
 
-            if (sqlValue.GetType() == typeof(System.DateTime))
-                return ConvertDateTime(dataType, (System.DateTime)sqlValue);
+            if (sqlValue.GetType() == typeof(DateTime))
+                return ConvertDateTime(dataType, (DateTime)sqlValue);
 
             if (sqlValue.GetType() == typeof(long))
                 return ((long)sqlValue).ToString();
@@ -194,24 +189,12 @@ namespace Peachpie.Library.MySql
             if (sqlValue.GetType() == typeof(byte[]))
                 return (byte[])sqlValue;
 
-            //MySqlDateTime sql_date_time = sqlValue as MySqlDateTime;
-            if (sqlValue.GetType() == typeof(MySqlDateTime))
-            {
-                MySqlDateTime sql_date_time = (MySqlDateTime)sqlValue;
-                if (sql_date_time.IsValidDateTime)
-                    return ConvertDateTime(dataType, sql_date_time.GetDateTime());
-
-                if (dataType == "DATE" || dataType == "NEWDATE")
-                    return "0000-00-00";
-                else
-                    return "0000-00-00 00:00:00";
-            }
-
+           
             Debug.Fail("Unexpected DB field type " + sqlValue.GetType() + ".");
             return sqlValue.ToString();
         }
 
-        private static string ConvertDateTime(string dataType, System.DateTime value)
+        private static string ConvertDateTime(string dataType, DateTime value)
         {
             if (dataType == "DATE" || dataType == "NEWDATE")
                 return value.ToString("yyyy-MM-dd");

--- a/src/Peachpie.Library.MySql/Peachpie.Library.MySql.csproj
+++ b/src/Peachpie.Library.MySql/Peachpie.Library.MySql.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Peachpie.Library.MySql</AssemblyName>
     <PackageId>Peachpie.Library.MySql</PackageId>
     <PackageTags>peachpie;library;mysql</PackageTags>
@@ -21,7 +21,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/src/Peachpie.Library.MySql/Peachpie.Library.MySql.csproj
+++ b/src/Peachpie.Library.MySql/Peachpie.Library.MySql.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Peachpie.Library.MySql</AssemblyName>
     <PackageId>Peachpie.Library.MySql</PackageId>
     <PackageTags>peachpie;library;mysql</PackageTags>
@@ -16,11 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySql.Data" Version="7.0.7-M61" />
+    <PackageReference Include="MySqlConnector" Version="0.40.4" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
+  
 </Project>

--- a/src/Peachpie.Library.MySql/Peachpie.Library.MySql.csproj
+++ b/src/Peachpie.Library.MySql/Peachpie.Library.MySql.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Peachpie.Library.MySql</AssemblyName>
     <PackageId>Peachpie.Library.MySql</PackageId>
     <PackageTags>peachpie;library;mysql</PackageTags>

--- a/src/Peachpie.Library.Network/Peachpie.Library.Network.csproj
+++ b/src/Peachpie.Library.Network/Peachpie.Library.Network.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;1574</NoWarn>
     <AssemblyName>Peachpie.Library.Network</AssemblyName>
     <PackageId>Peachpie.Library.Network</PackageId>

--- a/src/Peachpie.Library.Scripting/Peachpie.Library.Scripting.csproj
+++ b/src/Peachpie.Library.Scripting/Peachpie.Library.Scripting.csproj
@@ -25,12 +25,6 @@
     <ProjectReference Include="..\Peachpie.Library\Peachpie.Library.csproj" />
     <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-	<Reference Include="System.Core" />
-	<Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />

--- a/src/Peachpie.Library.Scripting/Peachpie.Library.Scripting.csproj
+++ b/src/Peachpie.Library.Scripting/Peachpie.Library.Scripting.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;1574</NoWarn>
     <AssemblyName>Peachpie.Library.Scripting</AssemblyName>
     <PackageId>Peachpie.Library.Scripting</PackageId>
@@ -10,28 +10,19 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>Support for dynamic code evaluation in Peachpie application. The package enables `eval` and `create_function` in compiled programs.</Description>
   </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'net46' ">
-		<DefineConstants>$(DefineConstants);NETSTANDARD1_5</DefineConstants>
-  </PropertyGroup>
-  
+ 
   <ItemGroup>
     <PackageReference Include="Devsense.Php.Parser" Version="1.4.48" />
     <PackageReference Include="Peachpie.Microsoft.CodeAnalysis" Version="0.6.0" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Peachpie.CodeAnalysis\Peachpie.CodeAnalysis.csproj" />
     <ProjectReference Include="..\Peachpie.Library\Peachpie.Library.csproj" />
     <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
-  </ItemGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.5' ">
     <ProjectReference Include="..\Peachpie.Library.XmlDom\Peachpie.Library.XmlDom.csproj" />
   </ItemGroup>
+ 
 
 </Project>

--- a/src/Peachpie.Library.Scripting/PhpCompilationFactory.cs
+++ b/src/Peachpie.Library.Scripting/PhpCompilationFactory.cs
@@ -10,9 +10,7 @@ using Pchp.CodeAnalysis;
 namespace Peachpie.Library.Scripting
 {
     class PhpCompilationFactory
-#if !NET46
         : System.Runtime.Loader.AssemblyLoadContext
-#endif
     {
         public PhpCompilationFactory()
         {
@@ -93,11 +91,8 @@ namespace Peachpie.Library.Scripting
 
         public Assembly LoadFromStream(AssemblyName assemblyName, MemoryStream peStream, MemoryStream pdbStream)
         {
-#if NET46
-            Assembly assembly = Assembly.Load(peStream.ToArray(), pdbStream?.ToArray());
-#else
-            Assembly assembly = this.LoadFromStream(peStream, pdbStream);
-#endif
+            var assembly = Assembly.Load(peStream.ToArray(), pdbStream?.ToArray());
+
             if (assembly != null)
             {
                 _assemblies.Add(assemblyName.Name, assembly);

--- a/src/Peachpie.Library.Scripting/PhpCompilationFactory.cs
+++ b/src/Peachpie.Library.Scripting/PhpCompilationFactory.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis;
 
@@ -19,7 +18,7 @@ namespace Peachpie.Library.Scripting
                 syntaxTrees: Array.Empty<PhpSyntaxTree>(),
                 options: new PhpCompilationOptions(
                     outputKind: OutputKind.DynamicallyLinkedLibrary,
-                    baseDirectory: System.IO.Directory.GetCurrentDirectory(),
+                    baseDirectory: Directory.GetCurrentDirectory(),
                     sdkDirectory: null));
 
             // bind reference manager, cache all references
@@ -91,18 +90,17 @@ namespace Peachpie.Library.Scripting
 
         public Assembly LoadFromStream(AssemblyName assemblyName, MemoryStream peStream, MemoryStream pdbStream)
         {
-            var assembly = Assembly.Load(peStream.ToArray(), pdbStream?.ToArray());
+            var assembly = this.LoadFromStream(peStream, pdbStream);
 
             if (assembly != null)
             {
                 _assemblies.Add(assemblyName.Name, assembly);
             }
+
             return assembly;
         }
 
-#if !NET46
         protected override Assembly Load(AssemblyName assemblyName) => TryGetSubmissionAssembly(assemblyName);
-#endif
 
         static int _counter = 0;
 

--- a/src/Peachpie.Library.XmlDom/Peachpie.Library.XmlDom.csproj
+++ b/src/Peachpie.Library.XmlDom/Peachpie.Library.XmlDom.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.6.7" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XPath" Version="4.3.0" />
@@ -24,12 +23,10 @@
     <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
     <ProjectReference Include="..\Peachpie.Library\Peachpie.Library.csproj" />
   </ItemGroup>
-
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+  </ItemGroup>  
 
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">

--- a/src/Peachpie.Library.XmlDom/Peachpie.Library.XmlDom.csproj
+++ b/src/Peachpie.Library.XmlDom/Peachpie.Library.XmlDom.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;1574</NoWarn>
     <AssemblyName>Peachpie.Library.XmlDom</AssemblyName>
     <PackageId>Peachpie.Library.XmlDom</PackageId>
@@ -23,10 +23,6 @@
     <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
     <ProjectReference Include="..\Peachpie.Library\Peachpie.Library.csproj" />
   </ItemGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-  </ItemGroup>  
 
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">

--- a/src/Peachpie.Library.XmlDom/Peachpie.Library.XmlDom.csproj
+++ b/src/Peachpie.Library.XmlDom/Peachpie.Library.XmlDom.csproj
@@ -12,8 +12,11 @@
     <NetStandardImplicitPackageVersion></NetStandardImplicitPackageVersion><!-- Clean up the default value -->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.8.2" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.6.7" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XPath" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Peachpie.Library.XmlDom/Peachpie.Library.XmlDom.csproj
+++ b/src/Peachpie.Library.XmlDom/Peachpie.Library.XmlDom.csproj
@@ -12,11 +12,8 @@
     <NetStandardImplicitPackageVersion></NetStandardImplicitPackageVersion><!-- Clean up the default value -->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.6.7" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.8.2" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XPath" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Peachpie.Library/Filter.cs
+++ b/src/Peachpie.Library/Filter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using Pchp.Core;
@@ -624,11 +625,11 @@ namespace Pchp.Library
             private static string DomainMapper(Match match)
             {
                 string domainName = match.Groups[2].Value;
-#if NET46
+
                 // IdnMapping class with default property values.
-                var idn = new System.Globalization.IdnMapping();
+                var idn = new IdnMapping();
                 domainName = idn.GetAscii(domainName);
-#endif
+
                 return match.Groups[1].Value + domainName;
             }
         }

--- a/src/Peachpie.Library/Peachpie.Library.csproj
+++ b/src/Peachpie.Library/Peachpie.Library.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;1574</NoWarn>
     <AssemblyName>Peachpie.Library</AssemblyName>
     <PackageId>Peachpie.Library</PackageId>
@@ -13,19 +13,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-	  <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
  
   <ItemGroup>

--- a/src/Peachpie.Library/Peachpie.Library.csproj
+++ b/src/Peachpie.Library/Peachpie.Library.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net46</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;1574</NoWarn>
     <AssemblyName>Peachpie.Library</AssemblyName>
     <PackageId>Peachpie.Library</PackageId>
@@ -15,22 +15,19 @@
     <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+	  <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-	<PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-	<PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-	<PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-	<Reference Include="System.Core" />
-	<Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
+ 
   <ItemGroup>
     <Compile Update="Resources\Resources.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/src/Peachpie.NET.Sdk/Peachpie.NET.Sdk.csproj
+++ b/src/Peachpie.NET.Sdk/Peachpie.NET.Sdk.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Peachpie.NET.Sdk</AssemblyName>
     <PackageId>Peachpie.NET.Sdk</PackageId>
     

--- a/src/Peachpie.NETCore.Web/Peachpie.NETCore.Web.csproj
+++ b/src/Peachpie.NETCore.Web/Peachpie.NETCore.Web.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Peachpie.NETCore.Web</AssemblyName>
     <PackageId>Peachpie.NETCore.Web</PackageId>
@@ -16,21 +16,10 @@
     <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Session" Version="1.1.2" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Session" Version="2.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Session" Version="2.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Peachpie.NETCore.Web/RequestContextCore.cs
+++ b/src/Peachpie.NETCore.Web/RequestContextCore.cs
@@ -127,16 +127,9 @@ namespace Peachpie.Web
         {
             get
             {
-#if NETSTANDARD2_0
-                // since 2.0.0
                 var maxsize = _httpctx.Features.Get<IHttpMaxRequestBodySizeFeature>()?.MaxRequestBodySize;
-                if (maxsize.HasValue)
-                {
-                    return maxsize.Value;
-                }
-#endif
-                // default:
-                return 30_000_000;
+             
+                return maxsize ?? 30_000_000;
             }
         }
 

--- a/src/Peachpie.Runtime/Peachpie.Runtime.csproj
+++ b/src/Peachpie.Runtime/Peachpie.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.5;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Peachpie.Runtime</AssemblyName>
     <PackageId>Peachpie.Runtime</PackageId>
@@ -17,22 +17,23 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.1" />
-    <PackageReference Include="System.Composition" Version="1.0.31" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.0" />
+    <PackageReference Include="System.Composition" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
+ 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Peachpie.Runtime/Peachpie.Runtime.csproj
+++ b/src/Peachpie.Runtime/Peachpie.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Peachpie.Runtime</AssemblyName>
     <PackageId>Peachpie.Runtime</PackageId>
@@ -15,24 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
     <PackageReference Include="System.Composition" Version="1.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-  </ItemGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-  </ItemGroup>
- 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Peachpie.Runtime/Reflection/PhpStackTrace.cs
+++ b/src/Peachpie.Runtime/Reflection/PhpStackTrace.cs
@@ -111,21 +111,8 @@ namespace Pchp.Core.Reflection
         public PhpStackTrace()
         {
             // collect stack trace if possible:
-#if NET46
             InitPhpStackFrames(new StackTrace(true));
-#else
-            // only available on netstandard2.0+
-            var ctor = typeof(StackTrace).GetConstructor(Dynamic.Cache.Types.Bool);
-            if (ctor != null)
-            {
-                var st = (StackTrace)ctor.Invoke(new object[] { true });
-                InitPhpStackFrames(st);
-            }
-            else
-            {
-                _frames = Array.Empty<PhpStackFrame>();
-            }
-#endif
+
             Debug.Assert(_frames != null);
         }
 

--- a/src/Runtime/Peachpie.RequestHandler/Peachpie.RequestHandler.csproj
+++ b/src/Runtime/Peachpie.RequestHandler/Peachpie.RequestHandler.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Peachpie.RequestHandler</AssemblyName>
     <PackageId>Peachpie.RequestHandler</PackageId>
@@ -14,10 +14,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Peachpie.Library\Peachpie.Library.csproj" />
     <ProjectReference Include="..\..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System.Web" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Runtime/Peachpie.RequestHandler/Peachpie.RequestHandler.csproj
+++ b/src/Runtime/Peachpie.RequestHandler/Peachpie.RequestHandler.csproj
@@ -18,8 +18,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Web" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Peachpie.Runtime.Tests/Peachpie.Runtime.Tests.csproj
+++ b/src/Tests/Peachpie.Runtime.Tests/Peachpie.Runtime.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This commit adds .NETSTANDARD2.0 targets to the peachpie libraries to reduce the dependencies on modern platforms. 

It also switches out the Oracle MySql library with the open source MySQLConnector library. This is used in the latest TechEmpower benchmarks, much faster than the Oracle library, and isn't subject to Oracles licensing terms.