### PR TITLE
Improve Code Quality

### DIFF
--- a/build/install_dependencies_ubuntu14.sh
+++ b/build/install_dependencies_ubuntu14.sh
@@ -1,14 +1,15 @@
 # Install .NET Core (see https://www.microsoft.com/net/core#ubuntu)
 
 # Add the dotnet apt-get feed (for .NET Core)
-sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
+sudo wget -q https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
 
 # Update apt-get cache
+sudo apt-get install apt-transport-https
 sudo apt-get update
 
 # Install .NET Core SDK
-sudo apt-get install dotnet-sdk-2.0.0 -y
+sudo apt-get install dotnet-sdk-2.1 -y
 
 
 # Install Powershell (https://www.rootusers.com/how-to-install-powershell-on-linux)

--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Convert.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Convert.cs
@@ -1,18 +1,12 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using System.Diagnostics;
+using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.FlowAnalysis;
 using Pchp.CodeAnalysis.Semantics;
-using Pchp.CodeAnalysis.Semantics.Graph;
 using Pchp.CodeAnalysis.Symbols;
 using Peachpie.CodeAnalysis.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.CodeGen
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
@@ -1,9 +1,14 @@
-﻿using Devsense.PHP.Syntax;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection.Metadata;
+using Devsense.PHP.Syntax;
 using Devsense.PHP.Syntax.Ast;
 using Devsense.PHP.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.Errors;
 using Pchp.CodeAnalysis.FlowAnalysis;
@@ -11,14 +16,6 @@ using Pchp.CodeAnalysis.Semantics;
 using Pchp.CodeAnalysis.Semantics.Graph;
 using Pchp.CodeAnalysis.Symbols;
 using Peachpie.CodeAnalysis.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.CodeGen
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Locals.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Locals.cs
@@ -1,14 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeGen;
-using Pchp.CodeAnalysis.Symbols;
-using Microsoft.CodeAnalysis;
-using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.Semantics;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.CodeGen
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Locals.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Locals.cs
@@ -208,9 +208,9 @@ namespace Pchp.CodeAnalysis.CodeGen
         /// <returns>Place or <c>null</c>.</returns>
         internal IPlace PlaceOrNull(BoundExpression expr)
         {
-            if (expr is BoundReferenceExpression)
+            if (expr is BoundReferenceExpression boundReference)
             {
-                return ((BoundReferenceExpression)expr).Place(_il);
+                return boundReference.Place(_il);
             }
 
             return null;

--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.TypeRef.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.TypeRef.cs
@@ -1,17 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.Emit;
-using Pchp.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.FlowAnalysis;
 using Pchp.CodeAnalysis.Symbols;
-using Pchp.CodeAnalysis.Semantics.Graph;
-using System.Reflection.Metadata;
-using System.Diagnostics;
 
 namespace Pchp.CodeAnalysis.CodeGen
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.cs
@@ -1,20 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.FlowAnalysis;
-using Pchp.CodeAnalysis.Symbols;
-using Pchp.CodeAnalysis.Semantics.Graph;
-using System.Reflection.Metadata;
-using System.Diagnostics;
-using System.Collections.Immutable;
-using Cci = Microsoft.Cci;
 using Pchp.CodeAnalysis.Semantics;
+using Pchp.CodeAnalysis.Semantics.Graph;
+using Pchp.CodeAnalysis.Symbols;
+using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.CodeGen
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/DynamicOperationFactory.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/DynamicOperationFactory.cs
@@ -1,15 +1,13 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeGen;
-using Pchp.CodeAnalysis.Semantics;
-using Pchp.CodeAnalysis.Symbols;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeGen;
+using Pchp.CodeAnalysis.Semantics;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.CodeGen
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/GhostMethodBuilder.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/GhostMethodBuilder.cs
@@ -1,12 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.Symbols;
-using Pchp.CodeAnalysis.CodeGen;
 
 namespace Pchp.CodeAnalysis.CodeGen
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundBlock.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundBlock.cs
@@ -1,13 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.CodeGen;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
 using Devsense.PHP.Text;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.Semantics.Graph

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundEdge.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundEdge.cs
@@ -1,16 +1,13 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeGen;
-using Pchp.CodeAnalysis.CodeGen;
-using Pchp.CodeAnalysis.Symbols;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeGen;
+using Pchp.CodeAnalysis.CodeGen;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.Semantics.Graph
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundExpression.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundExpression.cs
@@ -1,4 +1,10 @@
-﻿using Devsense.PHP.Syntax;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection.Metadata;
+using Devsense.PHP.Syntax;
 using Devsense.PHP.Syntax.Ast;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
@@ -6,15 +12,6 @@ using Microsoft.CodeAnalysis.Semantics;
 using Pchp.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.Symbols;
 using Peachpie.CodeAnalysis.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
-using BinaryKind = Microsoft.CodeAnalysis.Semantics.BinaryOperationKind;
 
 namespace Pchp.CodeAnalysis.Semantics
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundStatement.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundStatement.cs
@@ -1,15 +1,11 @@
-﻿using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.CodeGen;
-using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
-using Devsense.PHP.Text;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.FlowAnalysis;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.Semantics
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundTypeRef.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundTypeRef.cs
@@ -73,9 +73,9 @@ namespace Pchp.CodeAnalysis.Semantics
             {
                 return EmitLoadPhpTypeInfo(cg, this.ResolvedType);
             }
-            else if (_typeRef is ReservedTypeRef) // late static bound
+            else if (_typeRef is ReservedTypeRef reservedTypeRef) // late static bound
             {
-                switch (((ReservedTypeRef)_typeRef).Type)
+                switch (reservedTypeRef.Type)
                 {
                     case ReservedTypeRef.ReservedType.@static:
                         return EmitLoadStaticPhpTypeInfo(cg);

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundTypeRef.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundTypeRef.cs
@@ -1,13 +1,10 @@
-﻿using Devsense.PHP.Syntax.Ast;
-using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.CodeGen;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
+using Devsense.PHP.Syntax.Ast;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.Semantics

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundVariable.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundVariable.cs
@@ -1,19 +1,12 @@
-﻿using Devsense.PHP.Syntax.Ast;
+﻿using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.Text;
 using Pchp.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.FlowAnalysis;
 using Pchp.CodeAnalysis.Symbols;
 using Peachpie.CodeAnalysis.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Semantics

--- a/src/Peachpie.CodeAnalysis/CodeGen/MethodGenerator.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/MethodGenerator.cs
@@ -1,17 +1,10 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.Emit;
-using Pchp.CodeAnalysis.Semantics;
 using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.CodeGen

--- a/src/Peachpie.CodeAnalysis/CodeGen/Places.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Places.cs
@@ -1,18 +1,14 @@
-﻿using Devsense.PHP.Syntax;
+﻿using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection.Metadata;
+using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.FlowAnalysis;
 using Pchp.CodeAnalysis.Semantics;
 using Pchp.CodeAnalysis.Symbols;
 using Peachpie.CodeAnalysis.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.CodeGen

--- a/src/Peachpie.CodeAnalysis/CodeGen/Symbols/NamedTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Symbols/NamedTypeSymbol.cs
@@ -1,13 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.CodeGen;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SourceFieldSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SourceFieldSymbol.cs
@@ -1,12 +1,6 @@
-﻿using Pchp.CodeAnalysis.CodeGen;
-using Pchp.CodeAnalysis.Semantics;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
+﻿using System.Diagnostics;
 using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
+using Pchp.CodeAnalysis.CodeGen;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SourceRoutineSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SourceRoutineSymbol.cs
@@ -1,14 +1,11 @@
-﻿using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.CodeGen;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Pchp.CodeAnalysis.Emit;
 using System.Reflection.Metadata;
-using Pchp.CodeAnalysis.FlowAnalysis;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.CodeGen;
+using Pchp.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.Semantics;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SourceTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SourceTypeSymbol.cs
@@ -1,14 +1,10 @@
-﻿using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.CodeGen;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.CodeGen;
 using static Devsense.PHP.Syntax.Name;
-using System.Collections.Immutable;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SynthesizedStaticFieldsHolder.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SynthesizedStaticFieldsHolder.cs
@@ -1,11 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.CodeGen;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.CodeGen;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/CommandLine/PhpCommandLineArguments.cs
+++ b/src/Peachpie.CodeAnalysis/CommandLine/PhpCommandLineArguments.cs
@@ -1,10 +1,4 @@
 ﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.CommandLine
 {

--- a/src/Peachpie.CodeAnalysis/CommandLine/PhpCommandLineParser.cs
+++ b/src/Peachpie.CodeAnalysis/CommandLine/PhpCommandLineParser.cs
@@ -1,15 +1,14 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Emit;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.CommandLine
 {

--- a/src/Peachpie.CodeAnalysis/CommandLine/PhpCompiler.cs
+++ b/src/Peachpie.CodeAnalysis/CommandLine/PhpCompiler.cs
@@ -22,7 +22,7 @@ namespace Pchp.CodeAnalysis.CommandLine
 
         private readonly DiagnosticFormatter _diagnosticFormatter = new DiagnosticFormatter();
 
-        protected internal new PhpCommandLineArguments Arguments { get { return (PhpCommandLineArguments)base.Arguments; } }
+        protected internal new PhpCommandLineArguments Arguments => (PhpCommandLineArguments)base.Arguments;
 
         public PhpCompiler(CommandLineParser parser, string responseFile, string[] args, string clientDirectory, string baseDirectory, string sdkDirectory, string additionalReferenceDirectories, IAnalyzerAssemblyLoader analyzerLoader)
             : base(parser, responseFile, args, clientDirectory, baseDirectory, sdkDirectory, additionalReferenceDirectories, analyzerLoader)

--- a/src/Peachpie.CodeAnalysis/CommandLine/PhpCompiler.cs
+++ b/src/Peachpie.CodeAnalysis/CommandLine/PhpCompiler.cs
@@ -1,21 +1,15 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.VisualStudio.Shell.Interop;
 using System.Collections.Immutable;
 using System.IO;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
-using Devsense.PHP.Syntax;
-using Devsense.PHP.Errors;
-using Devsense.PHP.Text;
-using Pchp.CodeAnalysis.Errors;
-using Devsense.PHP.Syntax.Ast;
+using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
+using Devsense.PHP.Syntax;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.Shell.Interop;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.CommandLine
 {

--- a/src/Peachpie.CodeAnalysis/CommandLine/PhpCompilerDriver.cs
+++ b/src/Peachpie.CodeAnalysis/CommandLine/PhpCompilerDriver.cs
@@ -1,10 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.CommandLine
 {

--- a/src/Peachpie.CodeAnalysis/CommandLine/PhpParseOptions.cs
+++ b/src/Peachpie.CodeAnalysis/CommandLine/PhpParseOptions.cs
@@ -1,12 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/Compilation/PEModuleBuilder.cs
+++ b/src/Peachpie.CodeAnalysis/Compilation/PEModuleBuilder.cs
@@ -1,16 +1,13 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.Semantics.Model;
 using Pchp.CodeAnalysis.Symbols;
 using Peachpie.CodeAnalysis.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Emit
 {

--- a/src/Peachpie.CodeAnalysis/Compilation/PhpCompilation.Types.cs
+++ b/src/Peachpie.CodeAnalysis/Compilation/PhpCompilation.Types.cs
@@ -1,17 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.FlowAnalysis;
-using Pchp.CodeAnalysis.Symbols;
-using System.Diagnostics;
-using Pchp.CodeAnalysis.Semantics.Model;
-using Microsoft.CodeAnalysis.RuntimeMembers;
-using Roslyn.Utilities;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.RuntimeMembers;
+using Pchp.CodeAnalysis.FlowAnalysis;
+using Pchp.CodeAnalysis.Semantics.Model;
+using Pchp.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
 using AST = Devsense.PHP.Syntax.Ast;
 
 namespace Pchp.CodeAnalysis

--- a/src/Peachpie.CodeAnalysis/Compilation/PhpCompilation.cs
+++ b/src/Peachpie.CodeAnalysis/Compilation/PhpCompilation.cs
@@ -1,26 +1,23 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
-using System.Text;
+using System.Reflection.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
+using Devsense.PHP.Syntax;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Symbols;
-using Roslyn.Utilities;
-using System.Collections.Immutable;
-using System.IO;
-using System.Reflection.Metadata;
-using System.Threading;
-using System.Diagnostics;
+using Pchp.CodeAnalysis.DocumentationComments;
 using Pchp.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.Symbols;
-using Microsoft.CodeAnalysis.Collections;
-using System.Collections.Concurrent;
-using Devsense.PHP.Syntax;
-using Pchp.CodeAnalysis.DocumentationComments;
 using Pchp.CodeAnalysis.Utilities;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/Compilation/PhpCompilationOptions.cs
+++ b/src/Peachpie.CodeAnalysis/Compilation/PhpCompilationOptions.cs
@@ -1,11 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Collections.Immutable;
-using Roslyn.Utilities;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/Compilation/SourceCompiler.cs
+++ b/src/Peachpie.CodeAnalysis/Compilation/SourceCompiler.cs
@@ -1,21 +1,17 @@
-﻿using Devsense.PHP.Syntax;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Semantics;
 using Pchp.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.FlowAnalysis;
 using Pchp.CodeAnalysis.Semantics;
 using Pchp.CodeAnalysis.Semantics.Graph;
-using Pchp.CodeAnalysis.Semantics.Model;
 using Pchp.CodeAnalysis.Symbols;
-using Roslyn.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/Compilation/SynthesizedManager.cs
+++ b/src/Peachpie.CodeAnalysis/Compilation/SynthesizedManager.cs
@@ -1,12 +1,10 @@
-﻿using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.Emit
 {

--- a/src/Peachpie.CodeAnalysis/Constants.cs
+++ b/src/Peachpie.CodeAnalysis/Constants.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/DocumentationComments/CommentIdResolver.cs
+++ b/src/Peachpie.CodeAnalysis/DocumentationComments/CommentIdResolver.cs
@@ -10,8 +10,8 @@ namespace Pchp.CodeAnalysis.DocumentationComments
     {
         public static string GetId(Symbol symbol)
         {
-            if (symbol is MethodSymbol) return GetId((MethodSymbol)symbol);
-            if (symbol is TypeSymbol) return GetId((TypeSymbol)symbol);
+            if (symbol is MethodSymbol methodSymbol) return GetId(methodSymbol);
+            if (symbol is TypeSymbol typeSymbol) return GetId(typeSymbol);
 
             return null;
         }
@@ -22,9 +22,8 @@ namespace Pchp.CodeAnalysis.DocumentationComments
 
         static string TypeId(TypeSymbol type)
         {
-            if (type is ArrayTypeSymbol)
+            if (type is ArrayTypeSymbol arrtype)
             {
-                var arrtype = (ArrayTypeSymbol)type;
                 return TypeId(arrtype.ElementType) + "[]";  // TODO: MDSize
             }
             else if (type.ContainingType != null) // nested type

--- a/src/Peachpie.CodeAnalysis/DocumentationComments/CommentIdResolver.cs
+++ b/src/Peachpie.CodeAnalysis/DocumentationComments/CommentIdResolver.cs
@@ -1,11 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.DocumentationComments
 {

--- a/src/Peachpie.CodeAnalysis/DocumentationComments/DocumentationCommentCompiler.cs
+++ b/src/Peachpie.CodeAnalysis/DocumentationComments/DocumentationCommentCompiler.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
+using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.Symbols;
-using System.Text;
-using Devsense.PHP.Syntax;
 
 namespace Pchp.CodeAnalysis.DocumentationComments
 {

--- a/src/Peachpie.CodeAnalysis/DocumentationComments/PEDocumentationCommentUtils.cs
+++ b/src/Peachpie.CodeAnalysis/DocumentationComments/PEDocumentationCommentUtils.cs
@@ -1,10 +1,7 @@
-﻿using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.DocumentationComments
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/ArrayTypeSymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/ArrayTypeSymbolAdapter.cs
@@ -1,12 +1,9 @@
-﻿using Microsoft.CodeAnalysis.Emit;
-using Pchp.CodeAnalysis.Emit;
-using Roslyn.Utilities;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Emit;
+using Pchp.CodeAnalysis.Emit;
+using Roslyn.Utilities;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/ArrayTypeSymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/ArrayTypeSymbolAdapter.cs
@@ -27,13 +27,7 @@ namespace Pchp.CodeAnalysis.Symbols
             }
         }
 
-        bool Cci.IArrayTypeReference.IsSZArray
-        {
-            get
-            {
-                return this.IsSZArray;
-            }
-        }
+        bool Cci.IArrayTypeReference.IsSZArray => this.IsSZArray;
 
         IEnumerable<int> Cci.IArrayTypeReference.LowerBounds
         {
@@ -52,13 +46,7 @@ namespace Pchp.CodeAnalysis.Symbols
             }
         }
 
-        uint Cci.IArrayTypeReference.Rank
-        {
-            get
-            {
-                return (uint)this.Rank;
-            }
-        }
+        uint Cci.IArrayTypeReference.Rank => (uint)this.Rank;
 
         IEnumerable<ulong> Cci.IArrayTypeReference.Sizes
         {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/AssemblyReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/AssemblyReference.cs
@@ -1,15 +1,12 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Emit;
-using Pchp.CodeAnalysis.Symbols;
-using Roslyn.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
+using Pchp.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Emitter

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/AttributeDataAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/AttributeDataAdapter.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Emit;
-using Cci = Microsoft.Cci;
-using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.Emit;
+using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/CustomModifierAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/CustomModifierAdapter.cs
@@ -6,10 +6,7 @@ namespace Pchp.CodeAnalysis.Symbols
 {
     internal partial class CSharpCustomModifier : Cci.ICustomModifier
     {
-        bool Cci.ICustomModifier.IsOptional
-        {
-            get { return this.IsOptional; }
-        }
+        bool Cci.ICustomModifier.IsOptional => this.IsOptional;
 
         Cci.ITypeReference Cci.ICustomModifier.GetModifier(EmitContext context)
         {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/CustomModifierAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/CustomModifierAdapter.cs
@@ -1,10 +1,5 @@
 ﻿using Microsoft.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.Emit;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/FieldSymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/FieldSymbolAdapter.cs
@@ -1,12 +1,7 @@
-﻿using Microsoft.CodeAnalysis.Emit;
-using Pchp.CodeAnalysis.Emit;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Emit;
+using Pchp.CodeAnalysis.Emit;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/GenericMethodInstanceReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/GenericMethodInstanceReference.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Emit;
-using Cci = Microsoft.Cci;
 using Pchp.CodeAnalysis.Symbols;
+using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Emit
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/GenericNamespaceTypeInstanceReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/GenericNamespaceTypeInstanceReference.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Text;
-using Pchp.CodeAnalysis.Symbols;
+﻿using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.Emit
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/GenericTypeInstanceReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/GenericTypeInstanceReference.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.CodeAnalysis.Text;
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Emit;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using Cci = Microsoft.Cci;
-using Pchp.CodeAnalysis.Symbols;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
+using Pchp.CodeAnalysis.Symbols;
+using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Emit
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/MethodReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/MethodReference.cs
@@ -17,13 +17,7 @@ namespace Pchp.CodeAnalysis.Emit
             this.UnderlyingMethod = underlyingMethod;
         }
 
-        protected override Symbol UnderlyingSymbol
-        {
-            get
-            {
-                return UnderlyingMethod;
-            }
-        }
+        protected override Symbol UnderlyingSymbol => UnderlyingMethod;
 
         bool Cci.IMethodReference.AcceptsExtraArguments
         {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/MethodReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/MethodReference.cs
@@ -1,9 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
-using Cci = Microsoft.Cci;
 using Pchp.CodeAnalysis.Symbols;
+using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Emit
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/MethodSymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/MethodSymbolAdapter.cs
@@ -110,42 +110,15 @@ namespace Pchp.CodeAnalysis.Symbols
             }
         }
 
-        string Cci.INamedEntity.Name
-        {
-            get { return this.MetadataName; }
-        }
+        string Cci.INamedEntity.Name => this.MetadataName;
 
-        bool Cci.IMethodReference.AcceptsExtraArguments
-        {
-            get
-            {
-                return this.IsVararg;
-            }
-        }
+        bool Cci.IMethodReference.AcceptsExtraArguments => this.IsVararg;
 
-        ushort Cci.IMethodReference.GenericParameterCount
-        {
-            get
-            {
-                return (ushort)this.Arity;
-            }
-        }
+        ushort Cci.IMethodReference.GenericParameterCount => (ushort)this.Arity;
 
-        bool Cci.IMethodReference.IsGeneric
-        {
-            get
-            {
-                return this.IsGenericMethod;
-            }
-        }
+        bool Cci.IMethodReference.IsGeneric => this.IsGenericMethod;
 
-        ushort Cci.ISignature.ParameterCount
-        {
-            get
-            {
-                return (ushort)this.Parameters.Length;
-            }
-        }
+        ushort Cci.ISignature.ParameterCount => (ushort)this.Parameters.Length;
 
         Cci.IMethodDefinition Cci.IMethodReference.GetResolvedMethod(EmitContext context)
         {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/MethodSymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/MethodSymbolAdapter.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
+using Pchp.CodeAnalysis.Emit;
 using Roslyn.Utilities;
 using Cci = Microsoft.Cci;
-using Pchp.CodeAnalysis.Emit;
-using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/NamedTypeReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/NamedTypeReference.cs
@@ -19,45 +19,15 @@ namespace Pchp.CodeAnalysis.Emit
             this.UnderlyingNamedType = underlyingNamedType;
         }
 
-        ushort Cci.INamedTypeReference.GenericParameterCount
-        {
-            get
-            {
-                return (ushort)UnderlyingNamedType.Arity;
-            }
-        }
+        ushort Cci.INamedTypeReference.GenericParameterCount => (ushort)UnderlyingNamedType.Arity;
 
-        bool Cci.INamedTypeReference.MangleName
-        {
-            get
-            {
-                return UnderlyingNamedType.MangleName;
-            }
-        }
+        bool Cci.INamedTypeReference.MangleName => UnderlyingNamedType.MangleName;
 
-        string Cci.INamedEntity.Name
-        {
-            get
-            {
-                return UnderlyingNamedType.MetadataName;
-            }
-        }
+        string Cci.INamedEntity.Name => UnderlyingNamedType.MetadataName;
 
-        bool Cci.ITypeReference.IsEnum
-        {
-            get
-            {
-                return UnderlyingNamedType.IsEnumType();
-            }
-        }
+        bool Cci.ITypeReference.IsEnum => UnderlyingNamedType.IsEnumType();
 
-        bool Cci.ITypeReference.IsValueType
-        {
-            get
-            {
-                return UnderlyingNamedType.IsValueType;
-            }
-        }
+        bool Cci.ITypeReference.IsValueType => UnderlyingNamedType.IsValueType;
 
         Cci.ITypeDefinition Cci.ITypeReference.GetResolvedType(EmitContext context)
         {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/NamedTypeReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/NamedTypeReference.cs
@@ -2,8 +2,8 @@
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.Emit;
-using Roslyn.Utilities;
 using Pchp.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Emit

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -1,14 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
+using Pchp.CodeAnalysis.Emit;
 using Roslyn.Utilities;
 using Cci = Microsoft.Cci;
-using Pchp.CodeAnalysis.Emit;
-using Microsoft.CodeAnalysis;
-using System.Linq;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -24,15 +24,9 @@ namespace Pchp.CodeAnalysis.Symbols
         Cci.IGenericTypeInstanceReference,
         Cci.ISpecializedNestedTypeReference
     {
-        bool Cci.ITypeReference.IsEnum
-        {
-            get { return this.TypeKind == TypeKind.Enum; }
-        }
+        bool Cci.ITypeReference.IsEnum => this.TypeKind == TypeKind.Enum;
 
-        bool Cci.ITypeReference.IsValueType
-        {
-            get { return this.IsValueType; }
-        }
+        bool Cci.ITypeReference.IsValueType => this.IsValueType;
 
         Cci.ITypeDefinition Cci.ITypeReference.GetResolvedType(EmitContext context)
         {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/PEAssemblyBuilder.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Reflection;
-using Microsoft.CodeAnalysis.Emit;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
-using Cci = Microsoft.Cci;
+using Microsoft.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
+using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Emit
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/PEModuleBuilder.cs
@@ -4,16 +4,15 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection.PortableExecutable;
 using System.Threading;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Emit;
-using Roslyn.Utilities;
-using Microsoft.CodeAnalysis;
-using Cci = Microsoft.Cci;
 using Microsoft.CodeAnalysis.Emit.NoPia;
-using Pchp.CodeAnalysis.Symbols;
 using Pchp.CodeAnalysis.Emitter;
+using Pchp.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
+using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Emit
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/PENetModuleBuilder.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/PENetModuleBuilder.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Emit;
-using Roslyn.Utilities;
+﻿using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
 
 namespace Pchp.CodeAnalysis.Emit
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/ParameterSymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/ParameterSymbolAdapter.cs
@@ -1,15 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Roslyn.Utilities;
-using Cci = Microsoft.Cci;
 using System.Collections.Immutable;
-using Pchp.CodeAnalysis.Emit;
-using Microsoft.CodeAnalysis.Emit;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
+using Pchp.CodeAnalysis.Emit;
+using Roslyn.Utilities;
+using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/PointerTypeSymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/PointerTypeSymbolAdapter.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Reflection.Metadata;
+﻿using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.Emit;
 using Cci = Microsoft.Cci;

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/PointerTypeSymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/PointerTypeSymbolAdapter.cs
@@ -21,25 +21,16 @@ namespace Pchp.CodeAnalysis.Symbols
             }
         }
 
-        bool Cci.ITypeReference.IsEnum
-        {
-            get { return false; }
-        }
+        bool Cci.ITypeReference.IsEnum => false;
 
-        bool Cci.ITypeReference.IsValueType
-        {
-            get { return false; }
-        }
+        bool Cci.ITypeReference.IsValueType => false;
 
         Cci.ITypeDefinition Cci.ITypeReference.GetResolvedType(EmitContext context)
         {
             return null;
         }
 
-        TypeDefinitionHandle Cci.ITypeReference.TypeDef
-        {
-            get { return default(TypeDefinitionHandle); }
-        }
+        TypeDefinitionHandle Cci.ITypeReference.TypeDef => default(TypeDefinitionHandle);
 
         Cci.IGenericMethodParameterReference Cci.ITypeReference.AsGenericMethodParameterReference
         {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/PropertySymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/PropertySymbolAdapter.cs
@@ -1,12 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.Emit;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/SpecializedFieldReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/SpecializedFieldReference.cs
@@ -22,13 +22,7 @@ namespace Pchp.CodeAnalysis.Emit
             _underlyingField = underlyingField;
         }
 
-        protected override Symbol UnderlyingSymbol
-        {
-            get
-            {
-                return _underlyingField;
-            }
-        }
+        protected override Symbol UnderlyingSymbol => _underlyingField;
 
         public override void Dispatch(Cci.MetadataVisitor visitor)
         {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/SpecializedFieldReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/SpecializedFieldReference.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
-using Microsoft.CodeAnalysis.Text;
 using Pchp.CodeAnalysis.Symbols;
 using Cci = Microsoft.Cci;
 

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/SpecializedGenericNestedTypeInstanceReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/SpecializedGenericNestedTypeInstanceReference.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Emit;
 using System.Diagnostics;
-using Cci = Microsoft.Cci;
-using Pchp.CodeAnalysis.Symbols;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
+using Pchp.CodeAnalysis.Symbols;
+using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Emit
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/SpecializedMethodReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/SpecializedMethodReference.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Text;
-using Pchp.CodeAnalysis.Symbols;
+﻿using Pchp.CodeAnalysis.Symbols;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Emit

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/SymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/SymbolAdapter.cs
@@ -1,13 +1,10 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Emit;
-using Pchp.CodeAnalysis.Symbols;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
+using Pchp.CodeAnalysis.Symbols;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/TypeMemberReference.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/TypeMemberReference.cs
@@ -15,13 +15,7 @@ namespace Pchp.CodeAnalysis.Emit
             return moduleBeingBuilt.Translate(UnderlyingSymbol.ContainingType, context.SyntaxNodeOpt, context.Diagnostics);
         }
 
-        string Cci.INamedEntity.Name
-        {
-            get
-            {
-                return UnderlyingSymbol.MetadataName;
-            }
-        }
+        string Cci.INamedEntity.Name => UnderlyingSymbol.MetadataName;
 
         ///// <remarks>
         ///// Used only for testing.

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Reflection.Metadata;
-using Roslyn.Utilities;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Emit;
-using Cci = Microsoft.Cci;
+using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
 using Pchp.CodeAnalysis.Emit;
+using Roslyn.Utilities;
+using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -17,15 +17,9 @@ namespace Pchp.CodeAnalysis.Symbols
         Cci.IGenericMethodParameter,
         Cci.IGenericTypeParameter
     {
-        bool Cci.ITypeReference.IsEnum
-        {
-            get { return false; }
-        }
+        bool Cci.ITypeReference.IsEnum => false;
 
-        bool Cci.ITypeReference.IsValueType
-        {
-            get { return false; }
-        }
+        bool Cci.ITypeReference.IsValueType => false;
 
         Cci.ITypeDefinition Cci.ITypeReference.GetResolvedType(EmitContext context)
         {
@@ -187,18 +181,9 @@ namespace Pchp.CodeAnalysis.Symbols
             return null;
         }
 
-        string Cci.INamedEntity.Name
-        {
-            get { return this.MetadataName; }
-        }
+        string Cci.INamedEntity.Name => this.MetadataName;
 
-        ushort Cci.IParameterListEntry.Index
-        {
-            get
-            {
-                return (ushort)this.Ordinal;
-            }
-        }
+        ushort Cci.IParameterListEntry.Index => (ushort)this.Ordinal;
 
         Cci.IMethodReference Cci.IGenericMethodParameterReference.DefiningMethod
         {
@@ -246,21 +231,9 @@ namespace Pchp.CodeAnalysis.Symbols
             }
         }
 
-        bool Cci.IGenericParameter.MustBeReferenceType
-        {
-            get
-            {
-                return this.HasReferenceTypeConstraint;
-            }
-        }
+        bool Cci.IGenericParameter.MustBeReferenceType => this.HasReferenceTypeConstraint;
 
-        bool Cci.IGenericParameter.MustBeValueType
-        {
-            get
-            {
-                return this.HasValueTypeConstraint;
-            }
-        }
+        bool Cci.IGenericParameter.MustBeValueType => this.HasValueTypeConstraint;
 
         bool Cci.IGenericParameter.MustHaveDefaultConstructor
         {

--- a/src/Peachpie.CodeAnalysis/Errors/ErrorCode.cs
+++ b/src/Peachpie.CodeAnalysis/Errors/ErrorCode.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Pchp.CodeAnalysis.Errors
+﻿namespace Pchp.CodeAnalysis.Errors
 {
     /// <summary>
     /// A database of all possible diagnostics used by PHP compiler. The severity can be determined by the prefix:

--- a/src/Peachpie.CodeAnalysis/Errors/ErrorFacts.cs
+++ b/src/Peachpie.CodeAnalysis/Errors/ErrorFacts.cs
@@ -1,9 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System;
 using System.Globalization;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Errors
 {

--- a/src/Peachpie.CodeAnalysis/Errors/ErrorSink.cs
+++ b/src/Peachpie.CodeAnalysis/Errors/ErrorSink.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using Devsense.PHP.Errors;
-using Devsense.PHP.Syntax;
 using Devsense.PHP.Text;
 using Microsoft.CodeAnalysis;
-using System.Collections.Immutable;
 
 namespace Pchp.CodeAnalysis.Errors
 {

--- a/src/Peachpie.CodeAnalysis/Errors/MessageProvider.cs
+++ b/src/Peachpie.CodeAnalysis/Errors/MessageProvider.cs
@@ -1,10 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 using System.Globalization;
+using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Errors

--- a/src/Peachpie.CodeAnalysis/Errors/MessageProvider.cs
+++ b/src/Peachpie.CodeAnalysis/Errors/MessageProvider.cs
@@ -12,18 +12,9 @@ namespace Pchp.CodeAnalysis.Errors
     {
         public static readonly MessageProvider Instance = new MessageProvider();
 
-        public override string CodePrefix
-        {
-            get
-            {
-                return "PHP";
-            }
-        }
+        public override string CodePrefix => "PHP";
 
-        public override Type ErrorCodeType
-        {
-            get { return typeof(ErrorCode); }
-        }
+        public override Type ErrorCodeType => typeof(ErrorCode);
 
         public override int ERR_BadCompilationOptionValue => (int)ErrorCode.ERR_BadCompilationOptionValue;
 

--- a/src/Peachpie.CodeAnalysis/Errors/ParserMessageProvider.cs
+++ b/src/Peachpie.CodeAnalysis/Errors/ParserMessageProvider.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using System.Collections.Concurrent;
+using System.Globalization;
 using Devsense.PHP.Errors;
+using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Errors

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/AnalysisFacts.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/AnalysisFacts.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.Semantics;

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/AnalysisVisitor.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/AnalysisVisitor.cs
@@ -1,15 +1,7 @@
-﻿using Pchp.CodeAnalysis.Semantics.Graph;
-using System;
-using System.Collections.Generic;
+﻿using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Semantics;
-using System.Diagnostics;
 using Pchp.CodeAnalysis.Semantics;
-using Devsense.PHP.Text;
-using Devsense.PHP.Syntax;
-using Devsense.PHP.Syntax.Ast;
+using Pchp.CodeAnalysis.Semantics.Graph;
 
 namespace Pchp.CodeAnalysis.FlowAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/ConditionBranch.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/ConditionBranch.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Pchp.CodeAnalysis.FlowAnalysis
+﻿namespace Pchp.CodeAnalysis.FlowAnalysis
 {
     /// <summary>
     /// Whether the expression is evaluated as a part of branch condition.

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/FlowContext.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/FlowContext.cs
@@ -1,14 +1,9 @@
-﻿using Devsense.PHP.Syntax;
-using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.Semantics;
-using Pchp.CodeAnalysis.Symbols;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Devsense.PHP.Syntax;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.FlowAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/FlowState.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/FlowState.cs
@@ -1,13 +1,9 @@
-﻿using Devsense.PHP.Syntax;
-using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.Semantics;
-using Pchp.CodeAnalysis.Symbols;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Devsense.PHP.Syntax;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.FlowAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/Graph/BoundBlock.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/Graph/BoundBlock.cs
@@ -1,13 +1,6 @@
-﻿using Pchp.CodeAnalysis.FlowAnalysis;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Diagnostics;
-using Peachpie.CodeAnalysis.Utilities;
-using System.Collections.Concurrent;
+using Pchp.CodeAnalysis.FlowAnalysis;
 
 namespace Pchp.CodeAnalysis.Semantics.Graph
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/Graph/BoundExpression.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/Graph/BoundExpression.cs
@@ -1,10 +1,6 @@
-﻿using Pchp.CodeAnalysis.FlowAnalysis;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Pchp.CodeAnalysis.FlowAnalysis;
 
 namespace Pchp.CodeAnalysis.Semantics
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/Graph/ControlFlowGraph.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/Graph/ControlFlowGraph.cs
@@ -1,12 +1,5 @@
 ﻿using Devsense.PHP.Syntax;
-using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.FlowAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Semantics.Graph
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/IFlowState.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/IFlowState.cs
@@ -123,7 +123,7 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
 
         public override int GetHashCode() => _index * 2;
 
-        public override bool Equals(object obj) => obj is VariableHandle && ((VariableHandle)obj)._index == _index;
+        public override bool Equals(object obj) => obj is VariableHandle other && other._index == _index;
 
         #endregion
 

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/IFlowState.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/IFlowState.cs
@@ -1,10 +1,6 @@
-﻿using Devsense.PHP.Syntax;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Devsense.PHP.Syntax;
 
 namespace Pchp.CodeAnalysis.FlowAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/PHPDoc.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/PHPDoc.cs
@@ -1,9 +1,6 @@
-﻿using Devsense.PHP.Syntax;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Devsense.PHP.Syntax;
 
 namespace Pchp.CodeAnalysis.FlowAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/RoutineFlags.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/RoutineFlags.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.FlowAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/StateBinder.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/StateBinder.cs
@@ -1,12 +1,5 @@
-﻿using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Collections.Immutable;
-using Devsense.PHP.Syntax;
-using Devsense.PHP.Syntax.Ast;
+﻿using Devsense.PHP.Syntax;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.FlowAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/Symbols/SourceRoutineSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/Symbols/SourceRoutineSymbol.cs
@@ -1,10 +1,4 @@
 ﻿using Pchp.CodeAnalysis.FlowAnalysis;
-using Pchp.CodeAnalysis.Semantics.Graph;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/CallInfo.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/CallInfo.cs
@@ -1,9 +1,5 @@
-﻿using Devsense.PHP.Syntax;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
+using Devsense.PHP.Syntax;
 
 namespace Pchp.CodeAnalysis.FlowAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/PhpTypeCode.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/PhpTypeCode.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Pchp.CodeAnalysis.FlowAnalysis
+﻿namespace Pchp.CodeAnalysis.FlowAnalysis
 {
     /// <summary>
     /// Compatible PHP type codes.

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/TypeHelpers.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/TypeHelpers.cs
@@ -1,12 +1,5 @@
-﻿using Pchp.CodeAnalysis.FlowAnalysis;
-using Pchp.CodeAnalysis.Semantics;
+﻿using Pchp.CodeAnalysis.Semantics;
 using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.FlowAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/TypeRef.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/TypeRef.cs
@@ -25,17 +25,17 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
 
         #region ITypeRef Members
 
-        public QualifiedName QualifiedName { get { return _qname; } }
+        public QualifiedName QualifiedName => _qname;
 
-        public virtual ImmutableArray<ITypeRef> TypeArguments { get { return ImmutableArray<ITypeRef>.Empty; } }
+        public virtual ImmutableArray<ITypeRef> TypeArguments => ImmutableArray<ITypeRef>.Empty;
 
-        public bool IsObject { get { return true; } }
+        public bool IsObject => true;
 
-        public bool IsArray { get { return false; } }
+        public bool IsArray => false;
 
-        public bool IsPrimitiveType { get { return false; } }
+        public bool IsPrimitiveType => false;
 
-        public bool IsLambda { get { return false; } }
+        public bool IsLambda => false;
 
         public IEnumerable<object> Keys { get { throw new InvalidOperationException(); } }
 
@@ -45,7 +45,7 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
 
         public AST.Signature LambdaSignature { get { throw new InvalidOperationException(); } }
 
-        public PhpTypeCode TypeCode { get { return PhpTypeCode.Object; } }
+        public PhpTypeCode TypeCode => PhpTypeCode.Object;
 
         /// <summary>
         /// Gets corresponding CLR type for the type reference.
@@ -151,30 +151,27 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
 
         #region ITypeRef Members
 
-        public QualifiedName QualifiedName
-        {
-            get { return QualifiedName.Array; }
-        }
+        public QualifiedName QualifiedName => QualifiedName.Array;
 
-        public ImmutableArray<ITypeRef> TypeArguments { get { return ImmutableArray<ITypeRef>.Empty; } }
+        public ImmutableArray<ITypeRef> TypeArguments => ImmutableArray<ITypeRef>.Empty;
 
-        public bool IsObject { get { return false; } }
+        public bool IsObject => false;
 
-        public bool IsArray { get { return true; } }
+        public bool IsArray => true;
 
-        public bool IsPrimitiveType { get { return true; } }
+        public bool IsPrimitiveType => true;
 
-        public bool IsLambda { get { return false; } }
+        public bool IsLambda => false;
 
-        public IEnumerable<object> Keys { get { return (IEnumerable<object>)_keys ?? ArrayUtils.EmptyObjects; } }
+        public IEnumerable<object> Keys => (IEnumerable<object>)_keys ?? ArrayUtils.EmptyObjects;
 
-        public TypeRefMask ElementType { get { return _elementType; } }
+        public TypeRefMask ElementType => _elementType;
 
         public TypeRefMask LambdaReturnType { get { throw new InvalidOperationException(); } }
 
         public AST.Signature LambdaSignature { get { throw new InvalidOperationException(); } }
 
-        public PhpTypeCode TypeCode { get { return PhpTypeCode.PhpArray; } }
+        public PhpTypeCode TypeCode => PhpTypeCode.PhpArray;
 
         /// <summary>
         /// Gets corresponding CLR type for the type reference.
@@ -264,23 +261,23 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
             }
         }
 
-        public ImmutableArray<ITypeRef> TypeArguments { get { return ImmutableArray<ITypeRef>.Empty; } }
+        public ImmutableArray<ITypeRef> TypeArguments => ImmutableArray<ITypeRef>.Empty;
 
-        public bool IsObject { get { return _code == PhpTypeCode.Object; } }
+        public bool IsObject => _code == PhpTypeCode.Object;
 
-        public bool IsArray { get { return _code == PhpTypeCode.PhpArray; } }
+        public bool IsArray => _code == PhpTypeCode.PhpArray;
 
-        public bool IsPrimitiveType { get { return true; } }
+        public bool IsPrimitiveType => true;
 
-        public bool IsLambda { get { return false; } }
+        public bool IsLambda => false; 
 
-        public IEnumerable<object> Keys { get { return null; } }
+        public IEnumerable<object> Keys => null;
 
-        public TypeRefMask ElementType { get { return TypeRefMask.AnyType; } }
+        public TypeRefMask ElementType => TypeRefMask.AnyType;
 
-        public TypeRefMask LambdaReturnType { get { return TypeRefMask.AnyType; } }
+        public TypeRefMask LambdaReturnType => TypeRefMask.AnyType;
 
-        public AST.Signature LambdaSignature { get { return default(AST.Signature); } }
+        public AST.Signature LambdaSignature => default(AST.Signature);
 
         /// <summary>
         /// Gets underlaying type code of the primitive type.
@@ -360,36 +357,21 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
         /// <summary>
         /// Lambda function is of sub class of <c>Closure</c>.
         /// </summary>
-        public QualifiedName QualifiedName
-        {
-            get { return NameUtils.SpecialNames.Closure; }
-        }
+        public QualifiedName QualifiedName => NameUtils.SpecialNames.Closure;
 
-        public ImmutableArray<ITypeRef> TypeArguments { get { return ImmutableArray<ITypeRef>.Empty; } }
+        public ImmutableArray<ITypeRef> TypeArguments => ImmutableArray<ITypeRef>.Empty;
 
         /// <summary>
         /// Lambda function is an object of type <c>Closure</c>.
         /// This handles case when lambda is used as object with methods <c>bindTo</c> or <c>__invoke</c>.
         /// </summary>
-        public bool IsObject
-        {
-            get { return true; }
-        }
+        public bool IsObject => true;
 
-        public bool IsArray
-        {
-            get { return false; }
-        }
+        public bool IsArray => false;
 
-        public bool IsPrimitiveType
-        {
-            get { return false; }
-        }
+        public bool IsPrimitiveType => false;
 
-        public bool IsLambda
-        {
-            get { return true; }
-        }
+        public bool IsLambda => true;
 
         public IEnumerable<object> Keys
         {
@@ -401,11 +383,11 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
             get { throw new InvalidOperationException(); }
         }
 
-        public TypeRefMask LambdaReturnType { get { return _returnType; } }
+        public TypeRefMask LambdaReturnType => _returnType;
 
-        public AST.Signature LambdaSignature { get { return _signature; } }
+        public AST.Signature LambdaSignature => _signature;
 
-        public PhpTypeCode TypeCode { get { return PhpTypeCode.Object; } }
+        public PhpTypeCode TypeCode => PhpTypeCode.Object;
 
         /// <summary>
         /// Gets corresponding CLR type for the type reference.

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/TypeRefContext.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/TypeRefContext.cs
@@ -21,9 +21,9 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
         /// Its bits corresponds to <see cref="_typeRefs"/> indices.
         /// </summary>
         private ulong _isNullMask, _isObjectMask, _isArrayMask, _isLongMask, _isDoubleMask, _isBoolMask, _isStringMask, _isWritableStringMask, _isPrimitiveMask, _isLambdaMask;
-        private ulong IsNumberMask { get { return _isLongMask | _isDoubleMask; } }
-        private ulong IsAStringMask { get { return _isStringMask | _isWritableStringMask; } }
-        private ulong IsNullableMask { get { return _isNullMask | _isObjectMask | _isArrayMask | IsAStringMask | _isLambdaMask; } }
+        private ulong IsNumberMask =>_isLongMask | _isDoubleMask;
+        private ulong IsAStringMask =>_isStringMask | _isWritableStringMask;
+        private ulong IsNullableMask => _isNullMask | _isObjectMask | _isArrayMask | IsAStringMask | _isLambdaMask;
 
         ///// <summary>
         ///// Allowed types for array key.
@@ -641,7 +641,7 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
         /// <summary>
         /// Gets enumeration of all types in the context.
         /// </summary>
-        public IList<ITypeRef>/*!*/Types { get { return _typeRefs; } }
+        public IList<ITypeRef>/*!*/Types =>_typeRefs;
 
         /// <summary>
         /// Gets types referenced by given type mask.

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/TypeRefFactory.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/TypeRefFactory.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Immutable;
-using System.Diagnostics;
 using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.FlowAnalysis;

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/TypeRefMask.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/TypeRefMask.cs
@@ -61,24 +61,24 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
         /// <summary>
         /// Each bit corresponds to a type within its <see cref="TypeRefContext"/>.
         /// </summary>
-        public ulong Mask { get { return _mask; } }
+        public ulong Mask => _mask;
         private ulong _mask;
 
         /// <summary>
         /// Gets value indicating whether the type represents an any type.
         /// </summary>
-        public bool IsAnyType { get { return (_mask & AnyTypeMask) == AnyTypeMask; } }
+        public bool IsAnyType => (_mask & AnyTypeMask) == AnyTypeMask;
 
         /// <summary>
         /// Gets value indicating whether the type information is not initialized.
         /// </summary>
         /// <remarks>Also represents <c>void</c> type.</remarks>
-        public bool IsUninitialized { get { return _mask == (ulong)0; } }
+        public bool IsUninitialized => _mask == (ulong)0;
 
         /// <summary>
         /// Gets value indicating whether the type represents <c>void</c>.
         /// </summary>
-        public bool IsVoid { get { return (_mask & ~(ulong)(MaskFlags.Mask)) == 0; } }
+        public bool IsVoid => (_mask & ~(ulong)(MaskFlags.Mask)) == 0;
 
         /// <summary>
         /// Gets or sets value indicating whether the type might represent an alias.
@@ -136,7 +136,7 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
         /// <summary>
         /// Gets type mask representing any type.
         /// </summary>
-        public static TypeRefMask AnyType { get { return new TypeRefMask(AnyTypeMask); } }
+        public static TypeRefMask AnyType => new TypeRefMask(AnyTypeMask);
 
         #endregion
 

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/TypeRefMask.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/TypeRef/TypeRefMask.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 
 namespace Pchp.CodeAnalysis.FlowAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/Worklist.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/Worklist.cs
@@ -1,16 +1,9 @@
-﻿using Microsoft.CodeAnalysis.Semantics;
-using Pchp.CodeAnalysis.Semantics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
 using Pchp.CodeAnalysis.Semantics.Graph;
 using Pchp.CodeAnalysis.Symbols;
 using Pchp.CodeAnalysis.Utilities;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.FlowAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/Peachpie.CodeAnalysis.csproj
+++ b/src/Peachpie.CodeAnalysis/Peachpie.CodeAnalysis.csproj
@@ -10,6 +10,7 @@
     <PackageTags>php;peachpie;dotnet;compiler</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>Peachpie PHP language compiler platform.</Description>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Peachpie.CodeAnalysis/Semantics/BoundExpression.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/BoundExpression.cs
@@ -1,17 +1,14 @@
-﻿using Microsoft.CodeAnalysis.Semantics;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using System.Collections.Immutable;
-using Pchp.CodeAnalysis.FlowAnalysis;
 using System.Diagnostics;
-using Pchp.CodeAnalysis.Symbols;
-using Pchp.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CodeGen;
+using System.Linq;
 using Devsense.PHP.Syntax;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Semantics;
+using Pchp.CodeAnalysis.CodeGen;
+using Pchp.CodeAnalysis.FlowAnalysis;
+using Pchp.CodeAnalysis.Symbols;
 using Ast = Devsense.PHP.Syntax.Ast;
 
 namespace Pchp.CodeAnalysis.Semantics

--- a/src/Peachpie.CodeAnalysis/Semantics/BoundStatement.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/BoundStatement.cs
@@ -1,15 +1,10 @@
-﻿using Microsoft.CodeAnalysis.Semantics;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using Ast = Devsense.PHP.Syntax.Ast;
-using Microsoft.CodeAnalysis.Text;
 using Devsense.PHP.Syntax;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Semantics;
+using Microsoft.CodeAnalysis.Text;
+using Ast = Devsense.PHP.Syntax.Ast;
 
 namespace Pchp.CodeAnalysis.Semantics
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/BoundTypeRef.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/BoundTypeRef.cs
@@ -1,14 +1,10 @@
-﻿using Devsense.PHP.Syntax.Ast;
-using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Devsense.PHP.Syntax.Ast;
+using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.CodeGen;
-using System.Collections.Immutable;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.Semantics
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/BoundTypeRef.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/BoundTypeRef.cs
@@ -99,7 +99,7 @@ namespace Pchp.CodeAnalysis.Semantics
         /// <summary>
         /// Resolved type symbol if any.
         /// </summary>
-        public ITypeSymbol Symbol { get { return this.ResolvedType; } }
+        public ITypeSymbol Symbol => this.ResolvedType;
 
         /// <summary>
         /// Expression getting type name.

--- a/src/Peachpie.CodeAnalysis/Semantics/BoundVariable.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/BoundVariable.cs
@@ -1,16 +1,9 @@
-﻿using Microsoft.CodeAnalysis.Semantics;
-using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeGen;
-using Pchp.CodeAnalysis.CodeGen;
-using Pchp.CodeAnalysis.FlowAnalysis;
-using Devsense.PHP.Syntax;
+﻿using System;
 using System.Diagnostics;
+using Devsense.PHP.Syntax;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Semantics;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.Semantics
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/ExpressionsExtension.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/ExpressionsExtension.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Devsense.PHP.Syntax.Ast;
+﻿using Devsense.PHP.Syntax.Ast;
 
 namespace Pchp.CodeAnalysis.Semantics
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/Graph/BoundBlock.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Graph/BoundBlock.cs
@@ -2,7 +2,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Semantics;
 

--- a/src/Peachpie.CodeAnalysis/Semantics/Graph/BuilderVisitor.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Graph/BuilderVisitor.cs
@@ -1,12 +1,10 @@
-﻿using Devsense.PHP.Syntax;
-using Devsense.PHP.Syntax.Ast;
-using Devsense.PHP.Text;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Devsense.PHP.Syntax;
+using Devsense.PHP.Syntax.Ast;
+using Devsense.PHP.Text;
 
 namespace Pchp.CodeAnalysis.Semantics.Graph
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/Graph/ControlFlowGraph.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Graph/ControlFlowGraph.cs
@@ -1,11 +1,7 @@
-﻿using Devsense.PHP.Syntax;
+﻿using System;
+using System.Collections.Generic;
 using Devsense.PHP.Syntax.Ast;
 using Devsense.PHP.Text;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Semantics.Graph
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/Graph/Edge.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Graph/Edge.cs
@@ -1,10 +1,7 @@
-﻿using Microsoft.CodeAnalysis.Semantics;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System;
 using Devsense.PHP.Syntax;
 using Devsense.PHP.Syntax.Ast;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Peachpie.CodeAnalysis/Semantics/Graph/GraphVisitor.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Graph/GraphVisitor.cs
@@ -1,10 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Semantics;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
 
 namespace Pchp.CodeAnalysis.Semantics.Graph
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/IPhpOperation.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/IPhpOperation.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.Semantics;
 using Pchp.CodeAnalysis.FlowAnalysis;
 using Ast = Devsense.PHP.Syntax.Ast;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Semantics
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/LocalsTable.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/LocalsTable.cs
@@ -1,12 +1,9 @@
-﻿using Devsense.PHP.Syntax;
-using Pchp.CodeAnalysis.Symbols;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using Pchp.CodeAnalysis.Symbols;
 
 namespace Pchp.CodeAnalysis.Semantics
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/Model/GlobalSymbolProvider.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Model/GlobalSymbolProvider.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.Symbols;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Devsense.PHP.Syntax;
-using Roslyn.Utilities;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.Symbols;
 using Pchp.CodeAnalysis.Utilities;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Semantics.Model
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/Model/ISymbolProvider.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Model/ISymbolProvider.cs
@@ -1,11 +1,7 @@
-﻿using Devsense.PHP.Syntax;
+﻿using System.Collections.Generic;
+using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Semantics
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/Model/LocalSymbolProvider.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Model/LocalSymbolProvider.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.FlowAnalysis;

--- a/src/Peachpie.CodeAnalysis/Semantics/Model/SourceSymbolProvider.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Model/SourceSymbolProvider.cs
@@ -1,12 +1,10 @@
-﻿using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
+using Pchp.CodeAnalysis.Symbols;
 using Pchp.CodeAnalysis.Utilities;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Semantics.Model
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/PhpOperationVisitor.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/PhpOperationVisitor.cs
@@ -1,9 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Semantics;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 namespace Pchp.CodeAnalysis.Semantics
 {

--- a/src/Peachpie.CodeAnalysis/Semantics/SemanticsBinder.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/SemanticsBinder.cs
@@ -1,19 +1,17 @@
-﻿using Devsense.PHP.Syntax;
-using Devsense.PHP.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Semantics;
-using Pchp.CodeAnalysis.Symbols;
-using Roslyn.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AST = Devsense.PHP.Syntax.Ast;
-using Pchp.CodeAnalysis.Semantics.Graph;
+using Devsense.PHP.Syntax;
+using Devsense.PHP.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Semantics;
 using Pchp.CodeAnalysis.FlowAnalysis;
+using Pchp.CodeAnalysis.Semantics.Graph;
+using Pchp.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
+using AST = Devsense.PHP.Syntax.Ast;
 
 namespace Pchp.CodeAnalysis.Semantics
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/AbstractTypeMap.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/AbstractTypeMap.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/AbstractTypeParameterMap.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/AbstractTypeParameterMap.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+﻿using System.Diagnostics;
 using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/AmbiguousMethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/AmbiguousMethodSymbol.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.Semantics.Graph;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/AmbiguousMethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/AmbiguousMethodSymbol.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.Semantics.Graph;
 
 namespace Pchp.CodeAnalysis.Symbols
 {
@@ -140,11 +143,7 @@ namespace Pchp.CodeAnalysis.Symbols
     {
         readonly string _name;
 
-        public override ErrorMethodKind ErrorKind
-        {
-            get { return ErrorMethodKind.Missing; }
-
-        }
+        public override ErrorMethodKind ErrorKind => ErrorMethodKind.Missing;
 
         public override string Name => _name;
 

--- a/src/Peachpie.CodeAnalysis/Symbols/Anonymous/AnonymousTypeManager.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Anonymous/AnonymousTypeManager.cs
@@ -1,16 +1,13 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Collections;
-using Microsoft.CodeAnalysis.Symbols;
-using Roslyn.Utilities;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Anonymous/AnonymousTypeParameterSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Anonymous/AnonymousTypeParameterSymbol.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;

--- a/src/Peachpie.CodeAnalysis/Symbols/ArrayTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/ArrayTypeSymbol.cs
@@ -117,13 +117,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// Gets the list of custom modifiers associated with the array.
         /// Returns an empty list if there are no custom modifiers.
         /// </summary>
-        public ImmutableArray<CustomModifier> CustomModifiers
-        {
-            get
-            {
-                return _customModifiers;
-            }
-        }
+        public ImmutableArray<CustomModifier> CustomModifiers => _customModifiers;
 
         /// <summary>
         /// Gets the number of dimensions of the array. A regular single-dimensional array
@@ -146,26 +140,14 @@ namespace Pchp.CodeAnalysis.Symbols
         /// meaning that some trailing dimensions don't have the size specified.
         /// The most common case is none of the dimensions have the size specified - an empty array is returned.
         /// </summary>
-        internal virtual ImmutableArray<int> Sizes
-        {
-            get
-            {
-                return ImmutableArray<int>.Empty;
-            }
-        }
+        internal virtual ImmutableArray<int> Sizes => ImmutableArray<int>.Empty;
 
         /// <summary>
         /// Specified lower bounds for dimensions, by position. The length can be less than <see cref="Rank"/>,
         /// meaning that some trailing dimensions don't have the lower bound specified.
         /// The most common case is all dimensions are zero bound - a null array is returned in this case.
         /// </summary>
-        internal virtual ImmutableArray<int> LowerBounds
-        {
-            get
-            {
-                return default(ImmutableArray<int>);
-            }
-        }
+        internal virtual ImmutableArray<int> LowerBounds => default(ImmutableArray<int>);
 
         /// <summary>
         /// Note, <see cref="Rank"/> equality should be checked separately!!!
@@ -198,13 +180,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <summary>
         /// Gets the type of the elements stored in the array.
         /// </summary>
-        public TypeSymbol ElementType
-        {
-            get
-            {
-                return _elementType;
-            }
-        }
+        public TypeSymbol ElementType => _elementType;
 
         //internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
         //{
@@ -214,21 +190,9 @@ namespace Pchp.CodeAnalysis.Symbols
         //    }
         //}
 
-        public override bool IsReferenceType
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool IsReferenceType => true;
 
-        public override bool IsValueType
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool IsValueType => false;
 
         //internal sealed override bool IsManagedType
         //{
@@ -268,29 +232,11 @@ namespace Pchp.CodeAnalysis.Symbols
             return ImmutableArray<NamedTypeSymbol>.Empty;
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.ArrayType;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.ArrayType;
 
-        public override TypeKind TypeKind
-        {
-            get
-            {
-                return TypeKind.Array;
-            }
-        }
+        public override TypeKind TypeKind => TypeKind.Array;
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return null;
-            }
-        }
+        public override Symbol ContainingSymbol => null;
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
         {

--- a/src/Peachpie.CodeAnalysis/Symbols/ArrayTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/ArrayTypeSymbol.cs
@@ -1,12 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/AssemblySymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/AssemblySymbol.cs
@@ -62,13 +62,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// primitive types and the owning assembly cannot be used as the source too. Otherwise, it is one of 
         /// the referenced assemblies returned by GetReferencedAssemblySymbols() method or the owning assembly.
         /// </summary>
-        internal AssemblySymbol CorLibrary
-        {
-            get
-            {
-                return _corLibrary;
-            }
-        }
+        internal AssemblySymbol CorLibrary => _corLibrary;
 
         /// <summary>
         /// A helper method for ReferenceManager to set the system assembly, which provides primitive 

--- a/src/Peachpie.CodeAnalysis/Symbols/AssemblySymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/AssemblySymbol.cs
@@ -1,15 +1,12 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Collections.Immutable;
-using System.Globalization;
-using System.Threading;
-using Roslyn.Utilities;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Attributes/BaseAttributeData.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Attributes/BaseAttributeData.cs
@@ -3,13 +3,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
-using System.Reflection;
-using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Utilities;
-using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Attributes/PEAttributeData.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Attributes/PEAttributeData.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Threading;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/ConstructedMethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/ConstructedMethodSymbol.cs
@@ -16,12 +16,6 @@ namespace Pchp.CodeAnalysis.Symbols
             _typeArguments = typeArguments;
         }
 
-        public override ImmutableArray<TypeSymbol> TypeArguments
-        {
-            get
-            {
-                return _typeArguments;
-            }
-        }
+        public override ImmutableArray<TypeSymbol> TypeArguments => _typeArguments;
     }
 }

--- a/src/Peachpie.CodeAnalysis/Symbols/ConstructedMethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/ConstructedMethodSymbol.cs
@@ -1,10 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/ConstructedNamedTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/ConstructedNamedTypeSymbol.cs
@@ -36,10 +36,7 @@ namespace Pchp.CodeAnalysis.Symbols
         //    get { return TypeParameters.Cast<TypeParameterSymbol, TypeSymbol>(); }
         //}
 
-        public override NamedTypeSymbol ConstructedFrom
-        {
-            get { return this; }
-        }
+        public override NamedTypeSymbol ConstructedFrom => this;
     }
 
     /// <summary>
@@ -74,21 +71,9 @@ namespace Pchp.CodeAnalysis.Symbols
             Debug.Assert(constructedFrom.Arity != 0);
         }
 
-        public override NamedTypeSymbol ConstructedFrom
-        {
-            get
-            {
-                return _constructedFrom;
-            }
-        }
+        public override NamedTypeSymbol ConstructedFrom => _constructedFrom;
 
-        public override ImmutableArray<TypeSymbol> TypeArguments
-        {
-            get
-            {
-                return _typeArguments;
-            }
-        }
+        public override ImmutableArray<TypeSymbol> TypeArguments => _typeArguments;
 
         internal override bool HasTypeArgumentsCustomModifiers => _hasTypeArgumentsCustomModifiers;
 

--- a/src/Peachpie.CodeAnalysis/Symbols/ConstructedNamedTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/ConstructedNamedTypeSymbol.cs
@@ -1,8 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/CoreMembers.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/CoreMembers.cs
@@ -1,11 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/CustomModifier.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/CustomModifier.cs
@@ -76,10 +76,8 @@ namespace Pchp.CodeAnalysis.Symbols
                 {
                     return true;
                 }
-
-                OptionalCustomModifier other = obj as OptionalCustomModifier;
-
-                return other != null && other.modifier.Equals(this.modifier);
+                
+                return obj is OptionalCustomModifier other && other.modifier.Equals(this.modifier);
             }
         }
 
@@ -102,10 +100,8 @@ namespace Pchp.CodeAnalysis.Symbols
                 {
                     return true;
                 }
-
-                RequiredCustomModifier other = obj as RequiredCustomModifier;
-
-                return other != null && other.modifier.Equals(this.modifier);
+                
+                return obj is RequiredCustomModifier other && other.modifier.Equals(this.modifier);
             }
         }
     }

--- a/src/Peachpie.CodeAnalysis/Symbols/CustomModifier.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/CustomModifier.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/CustomModifier.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/CustomModifier.cs
@@ -20,13 +20,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <summary>
         /// A type used as a tag that indicates which type of modification applies.
         /// </summary>
-        public override INamedTypeSymbol Modifier
-        {
-            get
-            {
-                return modifier;
-            }
-        }
+        public override INamedTypeSymbol Modifier => modifier;
 
         public abstract override int GetHashCode();
 
@@ -95,13 +89,7 @@ namespace Pchp.CodeAnalysis.Symbols
                 : base(modifier)
             { }
 
-            public override bool IsOptional
-            {
-                get
-                {
-                    return false;
-                }
-            }
+            public override bool IsOptional => false;
 
             public override int GetHashCode()
             {

--- a/src/Peachpie.CodeAnalysis/Symbols/ErrorTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/ErrorTypeSymbol.cs
@@ -96,13 +96,7 @@ namespace Pchp.CodeAnalysis.Symbols
 
         public override CandidateReason CandidateReason => CandidateReason.None;
 
-        internal override bool MangleName
-        {
-            get
-            {
-                return false;
-            }
-        }
+        internal override bool MangleName => false;
     }
 
     internal class MissingMetadataTypeSymbol : ErrorTypeSymbol
@@ -135,13 +129,7 @@ namespace Pchp.CodeAnalysis.Symbols
             {
             }
 
-            public override Symbol ContainingSymbol
-            {
-                get
-                {
-                    return _containingType;
-                }
-            }
+            public override Symbol ContainingSymbol => _containingType;
 
 
             public override SpecialType SpecialType

--- a/src/Peachpie.CodeAnalysis/Symbols/ErrorTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/ErrorTypeSymbol.cs
@@ -1,11 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Symbols/FieldSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/FieldSymbol.cs
@@ -28,13 +28,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <summary>
         /// Gets the type of this field.
         /// </summary>
-        public TypeSymbol Type
-        {
-            get
-            {
-                return GetFieldType(ConsList<FieldSymbol>.Empty);
-            }
-        }
+        public TypeSymbol Type => GetFieldType(ConsList<FieldSymbol>.Empty);
 
         internal abstract TypeSymbol GetFieldType(ConsList<FieldSymbol> fieldsBeingBound);
 
@@ -150,68 +144,32 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Field;
-            }
-        }
+        public sealed override SymbolKind Kind => SymbolKind.Field;
 
         /// <summary>
         /// Returns false because field can't be abstract.
         /// </summary>
-        public sealed override bool IsAbstract
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public sealed override bool IsAbstract => false;
 
         /// <summary>
         /// Returns false because field can't be defined externally.
         /// </summary>
-        public sealed override bool IsExtern
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public sealed override bool IsExtern => false;
 
         /// <summary>
         /// Returns false because field can't be overridden.
         /// </summary>
-        public sealed override bool IsOverride
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public sealed override bool IsOverride => false;
 
         /// <summary>
         /// Returns false because field can't be sealed.
         /// </summary>
-        public sealed override bool IsSealed
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public sealed override bool IsSealed => false;
 
         /// <summary>
         /// Returns false because field can't be virtual.
         /// </summary>
-        public sealed override bool IsVirtual
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public sealed override bool IsVirtual => false;
 
         /// <summary>
         /// True if this symbol has a special name (metadata flag SpecialName is set).

--- a/src/Peachpie.CodeAnalysis/Symbols/FieldSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/FieldSymbol.cs
@@ -1,17 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Emit;
-using Pchp.CodeAnalysis.Emit;
-using Pchp.CodeAnalysis.Semantics;
-using Roslyn.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
-using Pchp.CodeAnalysis.FlowAnalysis;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.Emit;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/MemberSymbolExtensions.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/MemberSymbolExtensions.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/MethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/MethodSymbol.cs
@@ -1,15 +1,10 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 using System.Collections.Immutable;
-using Pchp.CodeAnalysis.Semantics;
-using Pchp.CodeAnalysis.FlowAnalysis;
-using Pchp.CodeAnalysis.Semantics.Graph;
-using System.Reflection;
 using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.Semantics.Graph;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/MethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/MethodSymbol.cs
@@ -47,13 +47,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// True if this method is hidden if a derived type declares a method with the same name and signature. 
         /// If false, any method with the same name hides this method. This flag is ignored by the runtime and is only used by compilers.
         /// </summary>
-        public virtual bool HidesBaseMethodsByName
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public virtual bool HidesBaseMethodsByName => true;
 
         public virtual bool IsAsync => false;
 
@@ -70,13 +64,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <summary>
         /// Returns whether this method is generic; i.e., does it have any type parameters?
         /// </summary>
-        public virtual bool IsGenericMethod
-        {
-            get
-            {
-                return this.Arity != 0;
-            }
-        }
+        public virtual bool IsGenericMethod => this.Arity != 0;
 
         public virtual bool IsVararg => false;
 
@@ -130,13 +118,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <summary>
         /// If this method can be applied to an object, returns the type of object it is applied to.
         /// </summary>
-        public virtual ITypeSymbol ReceiverType
-        {
-            get
-            {
-                return this.ContainingType;
-            }
-        }
+        public virtual ITypeSymbol ReceiverType => this.ContainingType;
 
         public virtual IMethodSymbol ReducedFrom
         {

--- a/src/Peachpie.CodeAnalysis/Symbols/MethodSymbolExtensions.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/MethodSymbolExtensions.cs
@@ -1,9 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/MissingAssemblySymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/MissingAssemblySymbol.cs
@@ -21,34 +21,16 @@ namespace Pchp.CodeAnalysis.Symbols
             this.identity = identity;
         }
 
-        internal sealed override bool IsMissing
-        {
-            get
-            {
-                return true;
-            }
-        }
+        internal sealed override bool IsMissing => true;
 
-        internal override bool IsLinked
-        {
-            get
-            {
-                return false;
-            }
-        }
+        internal override bool IsLinked => false;
 
         internal override Symbol GetDeclaredSpecialTypeMember(SpecialMember member)
         {
             return null;
         }
 
-        public override AssemblyIdentity Identity
-        {
-            get
-            {
-                return identity;
-            }
-        }
+        public override AssemblyIdentity Identity => identity;
 
         public override Version AssemblyVersionPattern => null;
 
@@ -130,13 +112,7 @@ namespace Pchp.CodeAnalysis.Symbols
             throw Roslyn.Utilities.ExceptionUtilities.Unreachable;
         }
 
-        public override bool MightContainExtensionMethods
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool MightContainExtensionMethods => false;
 
         public override AssemblyMetadata GetMetadata() => null;
     }

--- a/src/Peachpie.CodeAnalysis/Symbols/MissingAssemblySymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/MissingAssemblySymbol.cs
@@ -2,9 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
 

--- a/src/Peachpie.CodeAnalysis/Symbols/ModuleSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/ModuleSymbol.cs
@@ -1,12 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/MutableTypeMap.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/MutableTypeMap.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/NamedTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/NamedTypeSymbol.cs
@@ -3,11 +3,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
-using Cci = Microsoft.Cci;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/NamespaceOrTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/NamespaceOrTypeSymbol.cs
@@ -1,9 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
-using System;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/NamespaceSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/NamespaceSymbol.cs
@@ -1,9 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Cci = Microsoft.Cci;
 using Microsoft.CodeAnalysis;
-using System;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/NamespaceSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/NamespaceSymbol.cs
@@ -27,13 +27,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// Returns whether this namespace is the unnamed, global namespace that is 
         /// at the root of all namespaces.
         /// </summary>
-        public virtual bool IsGlobalNamespace
-        {
-            get
-            {
-                return (object)ContainingNamespace == null;
-            }
-        }
+        public virtual bool IsGlobalNamespace => (object)ContainingNamespace == null;
 
         /// <summary>
         /// The kind of namespace: Module, Assembly or Compilation.

--- a/src/Peachpie.CodeAnalysis/Symbols/NonMissingAssemblySymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/NonMissingAssemblySymbol.cs
@@ -1,12 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/OverloadsList.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/OverloadsList.cs
@@ -1,12 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.FlowAnalysis;
-using Pchp.CodeAnalysis.Semantics;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.FlowAnalysis;
+using Pchp.CodeAnalysis.Semantics;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/OverrideOrHiddenMembersResult.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/OverrideOrHiddenMembersResult.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/MemberRefMetadataDecoder.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/MemberRefMetadataDecoder.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols.PE
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/MetadataDecoder.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/MetadataDecoder.cs
@@ -1,15 +1,11 @@
-﻿using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.Symbols.PE;
-using Roslyn.Utilities;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.Symbols.PE;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/PEAssemblySymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/PEAssemblySymbol.cs
@@ -1,12 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/PEFieldSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/PEFieldSymbol.cs
@@ -1,20 +1,14 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Emit;
-using Pchp.CodeAnalysis.Emit;
-using Roslyn.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
-using Pchp.CodeAnalysis.FlowAnalysis;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.Emit;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/PEGlobalNamespaceSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/PEGlobalNamespaceSymbol.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/PEMethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/PEMethodSymbol.cs
@@ -1,18 +1,16 @@
-﻿using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Cci;
-using System.Globalization;
 using System.Threading;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.DocumentationComments;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/PEModuleSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/PEModuleSymbol.cs
@@ -1,15 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using System.Collections.Concurrent;
-using System.Reflection.Metadata;
+using System.Collections.Immutable;
 using System.Diagnostics;
-using Cci = Microsoft.Cci;
+using System.Reflection.Metadata;
 using System.Threading;
+using Microsoft.CodeAnalysis;
+using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/PENamedTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/PENamedTypeSymbol.cs
@@ -1,19 +1,17 @@
-﻿using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Collections;
 using System.Threading;
 using Devsense.PHP.Syntax;
-using System.Globalization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
 using Pchp.CodeAnalysis.DocumentationComments;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/PENamespaceSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/PENamespaceSymbol.cs
@@ -1,13 +1,11 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Metadata;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/PEParameterSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/PEParameterSymbol.cs
@@ -1,16 +1,12 @@
-﻿using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/PEPropertySymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/PEPropertySymbol.cs
@@ -1,15 +1,11 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/PETypeParameterSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/PETypeParameterSymbol.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Threading;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PE/SymbolFactory.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PE/SymbolFactory.cs
@@ -1,11 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Symbols/ParameterSignature.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/ParameterSignature.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Immutable;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/ParameterSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/ParameterSymbol.cs
@@ -1,10 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Php/IPhpPropertySymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Php/IPhpPropertySymbol.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.CodeGen;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Symbols/Php/IPhpRoutineSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Php/IPhpRoutineSymbol.cs
@@ -1,10 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.FlowAnalysis;
 using Pchp.CodeAnalysis.Semantics.Graph;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Php/IPhpScriptTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Php/IPhpScriptTypeSymbol.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Php/IPhpTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Php/IPhpTypeSymbol.cs
@@ -1,9 +1,5 @@
 ﻿using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Php/IPhpValue.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Php/IPhpValue.cs
@@ -1,10 +1,4 @@
-﻿using Pchp.CodeAnalysis.FlowAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Pchp.CodeAnalysis.Symbols
+﻿namespace Pchp.CodeAnalysis.Symbols
 {
     /// <summary>
     /// An interface of symbols with a result value (field, routine, property).

--- a/src/Peachpie.CodeAnalysis/Symbols/Php/PhpFieldSymbolExtension.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Php/PhpFieldSymbolExtension.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Pchp.CodeAnalysis.Symbols
+﻿namespace Pchp.CodeAnalysis.Symbols
 {
     internal static class PhpFieldSymbolExtension
     {

--- a/src/Peachpie.CodeAnalysis/Symbols/Php/PhpParam.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Php/PhpParam.cs
@@ -1,9 +1,5 @@
 ﻿using Pchp.CodeAnalysis.FlowAnalysis;
 using Pchp.CodeAnalysis.Semantics;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Php/PhpRoutineSymbolExtensions.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Php/PhpRoutineSymbolExtensions.cs
@@ -1,14 +1,10 @@
-﻿using Devsense.PHP.Syntax;
-using Devsense.PHP.Syntax.Ast;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.FlowAnalysis;
 using Pchp.CodeAnalysis.Semantics;
 using Roslyn.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Php/PhpSignatureMask.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Php/PhpSignatureMask.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Pchp.CodeAnalysis.Symbols
+﻿namespace Pchp.CodeAnalysis.Symbols
 {
     /// <summary>
     /// Mask of single bits representing a true-false state.

--- a/src/Peachpie.CodeAnalysis/Symbols/Php/PhpTypeSymbolExtensions.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Php/PhpTypeSymbolExtensions.cs
@@ -1,9 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/PointerTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PointerTypeSymbol.cs
@@ -38,53 +38,20 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <summary>
         /// The list of custom modifiers, if any, associated with the pointer type.
         /// </summary>
-        public ImmutableArray<CustomModifier> CustomModifiers
-        {
-            get
-            {
-                return _customModifiers;
-            }
-        }
+        public ImmutableArray<CustomModifier> CustomModifiers => _customModifiers;
 
-        public override Accessibility DeclaredAccessibility
-        {
-            get { return Accessibility.NotApplicable; }
-        }
+        public override Accessibility DeclaredAccessibility => Accessibility.NotApplicable;
 
-        public override bool IsStatic
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool IsStatic => false;
 
-        public override bool IsAbstract
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool IsAbstract => false;
 
-        public override bool IsSealed
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool IsSealed => false;
 
         /// <summary>
         /// Gets the type of the storage location that an instance of the pointer type points to.
         /// </summary>
-        public TypeSymbol PointedAtType
-        {
-            get
-            {
-                return _pointedAtType;
-            }
-        }
+        public TypeSymbol PointedAtType => _pointedAtType;
 
         //internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
         //{

--- a/src/Peachpie.CodeAnalysis/Symbols/PointerTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PointerTypeSymbol.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PropertySymbol.cs
@@ -1,12 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/PropertySymbol.cs
@@ -26,13 +26,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// symbol by type substitution then OriginalDefinition gets the original symbol as it was defined in
         /// source or metadata.
         /// </summary>
-        public new virtual PropertySymbol OriginalDefinition
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public new virtual PropertySymbol OriginalDefinition => this;
 
         protected override sealed Symbol OriginalSymbolDefinition
         {
@@ -143,18 +137,12 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <summary>
         /// The 'get' accessor of the property, or null if the property is write-only.
         /// </summary>
-        public abstract MethodSymbol GetMethod
-        {
-            get;
-        }
-
+        public abstract MethodSymbol GetMethod { get; }
+        
         /// <summary>
         /// The 'set' accessor of the property, or null if the property is read-only.
         /// </summary>
-        public abstract MethodSymbol SetMethod
-        {
-            get;
-        }
+        public abstract MethodSymbol SetMethod { get; }
 
         internal abstract Cci.CallingConvention CallingConvention { get; }
 
@@ -265,13 +253,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <summary>
         /// Gets the kind of this symbol.
         /// </summary>
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Property;
-            }
-        }
+        public sealed override SymbolKind Kind => SymbolKind.Property;
 
         public bool HasRefOrOutParameter()
         {

--- a/src/Peachpie.CodeAnalysis/Symbols/ReferenceManager.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/ReferenceManager.cs
@@ -1,13 +1,11 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Roslyn.Utilities;
 using System.Collections.Immutable;
-using Pchp.CodeAnalysis.Symbols;
 using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/SignatureEqualityComparer.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/SignatureEqualityComparer.cs
@@ -1,9 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/ExplicitInterfaceHelpers.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/ExplicitInterfaceHelpers.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/ILambdaContainerSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/ILambdaContainerSymbol.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/IndexedTypeParameterSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/IndexedTypeParameterSymbol.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.Threading;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/MemberAttributesAdapter.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/MemberAttributesAdapter.cs
@@ -1,10 +1,5 @@
 ﻿using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceAssemblySymbol.cs
@@ -1,14 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 using System.Collections.Immutable;
-using System.Globalization;
-using System.Threading;
 using System.Diagnostics;
 using System.Reflection;
+using System.Threading;
+using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFieldSymbol.cs
@@ -1,18 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
-using System.Text;
+using System.Threading;
+using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
 using Pchp.CodeAnalysis.FlowAnalysis;
 using Pchp.CodeAnalysis.Semantics;
-using Devsense.PHP.Syntax;
-using Devsense.PHP.Syntax.Ast;
-using Pchp.CodeAnalysis.Utilities;
-using System.Globalization;
-using System.Threading;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFileSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFileSymbol.cs
@@ -2,12 +2,11 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
-using Pchp.CodeAnalysis.Utilities;
-using Devsense.PHP.Syntax.Ast;
-using static Pchp.CodeAnalysis.AstUtils;
 using Devsense.PHP.Syntax;
+using Devsense.PHP.Syntax.Ast;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.Utilities;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFunctionSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFunctionSymbol.cs
@@ -2,14 +2,10 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.Semantics;
-using Pchp.CodeAnalysis.Semantics.Graph;
-using Pchp.CodeAnalysis.FlowAnalysis;
-using Devsense.PHP.Syntax.Ast;
 using Devsense.PHP.Syntax;
+using Devsense.PHP.Syntax.Ast;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.FlowAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceGeneratorSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceGeneratorSymbol.cs
@@ -1,14 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.FlowAnalysis;
-using Devsense.PHP.Syntax.Ast;
-using Devsense.PHP.Syntax;
-using System.Collections.Immutable;
-using Devsense.PHP.Text;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceGlobalMethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceGlobalMethodSymbol.cs
@@ -2,14 +2,11 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.FlowAnalysis;
-using System.Diagnostics;
 using Devsense.PHP.Syntax;
 using Devsense.PHP.Syntax.Ast;
 using Devsense.PHP.Text;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.FlowAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
-using System.Threading.Tasks;
+using Devsense.PHP.Syntax;
+using Devsense.PHP.Syntax.Ast;
 using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.FlowAnalysis;
-using Devsense.PHP.Syntax.Ast;
-using Devsense.PHP.Syntax;
-using System.Collections.Immutable;
-using Devsense.PHP.Text;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceLocalSymbol.cs
@@ -1,11 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceMethodSymbol.cs
@@ -1,16 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.Semantics;
-using Pchp.CodeAnalysis.Semantics.Graph;
-using Pchp.CodeAnalysis.FlowAnalysis;
-using Devsense.PHP.Syntax.Ast;
 using Devsense.PHP.Syntax;
-using Microsoft.Cci;
+using Devsense.PHP.Syntax.Ast;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.FlowAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceModuleSymbol.cs
@@ -1,11 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceNamespaceSymbol.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Devsense.PHP.Syntax.Ast;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceRoutineSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceRoutineSymbol.cs
@@ -1,21 +1,15 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Semantics;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Devsense.PHP.Syntax;
+using Devsense.PHP.Syntax.Ast;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.FlowAnalysis;
 using Pchp.CodeAnalysis.Semantics;
 using Pchp.CodeAnalysis.Semantics.Graph;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Diagnostics;
-using Pchp.CodeAnalysis.CodeGen;
-using Pchp.CodeAnalysis.FlowAnalysis;
-using Devsense.PHP.Syntax.Ast;
-using Devsense.PHP.Syntax;
-using Devsense.PHP.Text;
-using System.Globalization;
-using System.Threading;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceSymbolCollection.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceSymbolCollection.cs
@@ -1,18 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Pchp.CodeAnalysis.Semantics;
-using Roslyn.Utilities;
-using Pchp.CodeAnalysis.Utilities;
+using System.Linq;
 using Devsense.PHP.Syntax;
 using Devsense.PHP.Syntax.Ast;
-using static Pchp.CodeAnalysis.AstUtils;
+using Microsoft.CodeAnalysis;
+using Pchp.CodeAnalysis.Utilities;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceTraitSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceTraitSymbol.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using Devsense.PHP.Syntax;
 using Devsense.PHP.Syntax.Ast;
 using Microsoft.CodeAnalysis;

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceTypeSymbol.cs
@@ -1,21 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
 using System.Diagnostics;
-using Pchp.CodeAnalysis.Semantics;
-using Devsense.PHP.Syntax.Ast;
-using Devsense.PHP.Syntax;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
+using Devsense.PHP.Syntax;
+using Devsense.PHP.Syntax.Ast;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
-using static Pchp.CodeAnalysis.AstUtils;
-using Pchp.CodeAnalysis.Utilities;
 using Pchp.CodeAnalysis.Errors;
+using Pchp.CodeAnalysis.Semantics;
+using Pchp.CodeAnalysis.Utilities;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/SpecialAssembly.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/SpecialAssembly.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Pchp.CodeAnalysis.Symbols
+﻿namespace Pchp.CodeAnalysis.Symbols
 {
     /// <summary>
     /// Anumeration of well known assemblies.

--- a/src/Peachpie.CodeAnalysis/Symbols/SpecialParameterSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/SpecialParameterSymbol.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using System.Diagnostics;
+using System.Linq;
 using Devsense.PHP.Syntax;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/SubstitutedFieldSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/SubstitutedFieldSymbol.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Collections.Immutable;
-using System.Threading;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
-using System.Globalization;
-using Microsoft.CodeAnalysis;
 using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+using Microsoft.CodeAnalysis;
 using Pchp.CodeAnalysis.CodeGen;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/SubstitutedFieldSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/SubstitutedFieldSymbol.cs
@@ -69,66 +69,24 @@ namespace Pchp.CodeAnalysis.Symbols
             return _lazyType;
         }
 
-        public override string Name
-        {
-            get
-            {
-                return _originalDefinition.Name;
-            }
-        }
+        public override string Name => _originalDefinition.Name;
 
         public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             return _originalDefinition.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken);
         }
 
-        internal override bool HasSpecialName
-        {
-            get
-            {
-                return _originalDefinition.HasSpecialName;
-            }
-        }
+        internal override bool HasSpecialName => _originalDefinition.HasSpecialName;
 
-        internal override bool HasRuntimeSpecialName
-        {
-            get
-            {
-                return _originalDefinition.HasRuntimeSpecialName;
-            }
-        }
+        internal override bool HasRuntimeSpecialName => _originalDefinition.HasRuntimeSpecialName;
 
-        internal override bool IsNotSerialized
-        {
-            get
-            {
-                return _originalDefinition.IsNotSerialized;
-            }
-        }
+        internal override bool IsNotSerialized => _originalDefinition.IsNotSerialized;
 
-        internal override int? TypeLayoutOffset
-        {
-            get
-            {
-                return _originalDefinition.TypeLayoutOffset;
-            }
-        }
+        internal override int? TypeLayoutOffset => _originalDefinition.TypeLayoutOffset;
 
-        public override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        public override Symbol ContainingSymbol => _containingType;
 
-        public override NamedTypeSymbol ContainingType
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        public override NamedTypeSymbol ContainingType => _containingType;
 
         internal void SetContainingType(SubstitutedNamedTypeSymbol type)
         {
@@ -138,34 +96,13 @@ namespace Pchp.CodeAnalysis.Symbols
             _containingType = type;
         }
 
-        public override FieldSymbol OriginalDefinition
-        {
-            get
-            {
-                return _originalDefinition.OriginalDefinition;
-            }
-        }
+        public override FieldSymbol OriginalDefinition => _originalDefinition.OriginalDefinition;
 
-        public override ImmutableArray<Location> Locations
-        {
-            get
-            {
-                return _originalDefinition.Locations;
-            }
-        }
+        public override ImmutableArray<Location> Locations => _originalDefinition.Locations;
 
-        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
-        {
-            get
-            {
-                return _originalDefinition.DeclaringSyntaxReferences;
-            }
-        }
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => _originalDefinition.DeclaringSyntaxReferences;
 
-        public override ImmutableArray<AttributeData> GetAttributes()
-        {
-            return _originalDefinition.GetAttributes();
-        }
+        public override ImmutableArray<AttributeData> GetAttributes() => _originalDefinition.GetAttributes();
 
         public override Symbol AssociatedSymbol
         {
@@ -182,82 +119,28 @@ namespace Pchp.CodeAnalysis.Symbols
             }
         }
 
-        public override bool IsStatic
-        {
-            get
-            {
-                return _originalDefinition.IsStatic;
-            }
-        }
+        public override bool IsStatic => _originalDefinition.IsStatic;
 
-        public override bool IsReadOnly
-        {
-            get
-            {
-                return _originalDefinition.IsReadOnly;
-            }
-        }
+        public override bool IsReadOnly => _originalDefinition.IsReadOnly;
 
-        public override bool IsConst
-        {
-            get
-            {
-                return _originalDefinition.IsConst;
-            }
-        }
+        public override bool IsConst => _originalDefinition.IsConst;
 
-        internal override ObsoleteAttributeData ObsoleteAttributeData
-        {
-            get
-            {
-                return _originalDefinition.ObsoleteAttributeData;
-            }
-        }
+        internal override ObsoleteAttributeData ObsoleteAttributeData => _originalDefinition.ObsoleteAttributeData;
 
-        public override object ConstantValue
-        {
-            get
-            {
-                return _originalDefinition.ConstantValue;
-            }
-        }
+        public override object ConstantValue => _originalDefinition.ConstantValue;
 
         internal override ConstantValue GetConstantValue(bool earlyDecodingWellKnownAttributes)
         {
             return _originalDefinition.GetConstantValue(earlyDecodingWellKnownAttributes);
         }
 
-        internal override MarshalPseudoCustomAttributeData MarshallingInformation
-        {
-            get
-            {
-                return _originalDefinition.MarshallingInformation;
-            }
-        }
+        internal override MarshalPseudoCustomAttributeData MarshallingInformation => _originalDefinition.MarshallingInformation;
 
-        public override bool IsVolatile
-        {
-            get
-            {
-                return _originalDefinition.IsVolatile;
-            }
-        }
+        public override bool IsVolatile => _originalDefinition.IsVolatile;
 
-        public override bool IsImplicitlyDeclared
-        {
-            get
-            {
-                return _originalDefinition.IsImplicitlyDeclared;
-            }
-        }
+        public override bool IsImplicitlyDeclared => _originalDefinition.IsImplicitlyDeclared;
 
-        public override Accessibility DeclaredAccessibility
-        {
-            get
-            {
-                return _originalDefinition.DeclaredAccessibility;
-            }
-        }
+        public override Accessibility DeclaredAccessibility => _originalDefinition.DeclaredAccessibility;
 
         public override ImmutableArray<CustomModifier> CustomModifiers
         {

--- a/src/Peachpie.CodeAnalysis/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/SubstitutedMethodSymbol.cs
@@ -1,13 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/SubstitutedMethodSymbol.cs
@@ -54,13 +54,7 @@ namespace Pchp.CodeAnalysis.Symbols
             }
         }
 
-        public override IMethodSymbol ConstructedFrom
-        {
-            get
-            {
-                return _constructedFrom;
-            }
-        }
+        public override IMethodSymbol ConstructedFrom => _constructedFrom;
 
         //public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
         //{
@@ -118,29 +112,11 @@ namespace Pchp.CodeAnalysis.Symbols
             }
         }
 
-        public sealed override int Arity
-        {
-            get
-            {
-                return originalDefinition.Arity;
-            }
-        }
+        public sealed override int Arity => originalDefinition.Arity;
 
-        public sealed override string Name
-        {
-            get
-            {
-                return originalDefinition.Name;
-            }
-        }
+        public sealed override string Name => originalDefinition.Name;
 
-        internal sealed override bool HasSpecialName
-        {
-            get
-            {
-                return originalDefinition.HasSpecialName;
-            }
-        }
+        internal sealed override bool HasSpecialName => originalDefinition.HasSpecialName;
 
         internal sealed override System.Reflection.MethodImplAttributes ImplementationAttributes
         {
@@ -150,13 +126,7 @@ namespace Pchp.CodeAnalysis.Symbols
             }
         }
 
-        internal sealed override bool RequiresSecurityObject
-        {
-            get
-            {
-                return originalDefinition.RequiresSecurityObject;
-            }
-        }
+        internal sealed override bool RequiresSecurityObject => originalDefinition.RequiresSecurityObject;
 
         public sealed override DllImportData GetDllImportData()
         {
@@ -183,13 +153,7 @@ namespace Pchp.CodeAnalysis.Symbols
         //    return originalDefinition.GetAppliedConditionalSymbols();
         //}
 
-        public sealed override AssemblySymbol ContainingAssembly
-        {
-            get
-            {
-                return originalDefinition.ContainingAssembly;
-            }
-        }
+        public sealed override AssemblySymbol ContainingAssembly => originalDefinition.ContainingAssembly;
 
         public sealed override ImmutableArray<Location> Locations
         {
@@ -223,69 +187,21 @@ namespace Pchp.CodeAnalysis.Symbols
             }
         }
 
-        public sealed override bool IsExtern
-        {
-            get
-            {
-                return originalDefinition.IsExtern;
-            }
-        }
+        public sealed override bool IsExtern => originalDefinition.IsExtern;
 
-        public sealed override bool IsSealed
-        {
-            get
-            {
-                return originalDefinition.IsSealed;
-            }
-        }
+        public sealed override bool IsSealed => originalDefinition.IsSealed;
 
-        public sealed override bool IsVirtual
-        {
-            get
-            {
-                return originalDefinition.IsVirtual;
-            }
-        }
+        public sealed override bool IsVirtual => originalDefinition.IsVirtual;
 
-        public sealed override bool IsAsync
-        {
-            get
-            {
-                return originalDefinition.IsAsync;
-            }
-        }
+        public sealed override bool IsAsync => originalDefinition.IsAsync;
 
-        public sealed override bool IsAbstract
-        {
-            get
-            {
-                return originalDefinition.IsAbstract;
-            }
-        }
+        public sealed override bool IsAbstract => originalDefinition.IsAbstract;
 
-        public sealed override bool IsOverride
-        {
-            get
-            {
-                return originalDefinition.IsOverride;
-            }
-        }
+        public sealed override bool IsOverride => originalDefinition.IsOverride;
 
-        public sealed override bool IsStatic
-        {
-            get
-            {
-                return originalDefinition.IsStatic;
-            }
-        }
+        public sealed override bool IsStatic => originalDefinition.IsStatic;
 
-        public sealed override bool IsExtensionMethod
-        {
-            get
-            {
-                return originalDefinition.IsExtensionMethod;
-            }
-        }
+        public sealed override bool IsExtensionMethod => originalDefinition.IsExtensionMethod;
 
         internal override ObsoleteAttributeData ObsoleteAttributeData
         {
@@ -327,63 +243,27 @@ namespace Pchp.CodeAnalysis.Symbols
             return this.TypeArguments[reducedFromTypeParameter.Ordinal];
         }
 
-        public sealed override IMethodSymbol ReducedFrom
-        {
-            get
-            {
-                return originalDefinition.ReducedFrom;
-            }
-        }
+        public sealed override IMethodSymbol ReducedFrom => originalDefinition.ReducedFrom;
 
-        public sealed override bool HidesBaseMethodsByName
-        {
-            get
-            {
-                return originalDefinition.HidesBaseMethodsByName;
-            }
-        }
+        public sealed override bool HidesBaseMethodsByName => originalDefinition.HidesBaseMethodsByName;
 
-        public sealed override Accessibility DeclaredAccessibility
-        {
-            get
-            {
-                return originalDefinition.DeclaredAccessibility;
-            }
-        }
+        public sealed override Accessibility DeclaredAccessibility => originalDefinition.DeclaredAccessibility;
 
         internal sealed override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false)
         {
             return originalDefinition.IsMetadataVirtual(ignoreInterfaceImplementationChanges);
         }
 
-        internal override bool IsMetadataFinal
-        {
-            get
-            {
-                return originalDefinition.IsMetadataFinal;
-            }
-        }
+        internal override bool IsMetadataFinal => originalDefinition.IsMetadataFinal;
 
         internal sealed override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
         {
             return originalDefinition.IsMetadataNewSlot(ignoreInterfaceImplementationChanges);
         }
 
-        public sealed override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        public sealed override Symbol ContainingSymbol => _containingType;
 
-        public override NamedTypeSymbol ContainingType
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        public override NamedTypeSymbol ContainingType => _containingType;
 
         public sealed override ImmutableArray<AttributeData> GetAttributes()
         {
@@ -399,29 +279,11 @@ namespace Pchp.CodeAnalysis.Symbols
             }
         }
 
-        public sealed override MethodKind MethodKind
-        {
-            get
-            {
-                return originalDefinition.MethodKind;
-            }
-        }
+        public sealed override MethodKind MethodKind => originalDefinition.MethodKind;
 
-        public sealed override bool ReturnsVoid
-        {
-            get
-            {
-                return originalDefinition.ReturnsVoid;
-            }
-        }
+        public sealed override bool ReturnsVoid => originalDefinition.ReturnsVoid;
 
-        public sealed override bool IsGenericMethod
-        {
-            get
-            {
-                return originalDefinition.IsGenericMethod;
-            }
-        }
+        public sealed override bool IsGenericMethod => originalDefinition.IsGenericMethod;
 
         public sealed override bool IsImplicitlyDeclared
         {
@@ -439,13 +301,7 @@ namespace Pchp.CodeAnalysis.Symbols
         //    }
         //}
 
-        public sealed override bool IsVararg
-        {
-            get
-            {
-                return originalDefinition.IsVararg;
-            }
-        }
+        public sealed override bool IsVararg => originalDefinition.IsVararg;
 
         public sealed override TypeSymbol ReturnType
         {

--- a/src/Peachpie.CodeAnalysis/Symbols/SubstitutedNamedTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/SubstitutedNamedTypeSymbol.cs
@@ -4,10 +4,9 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {
@@ -438,13 +437,7 @@ namespace Pchp.CodeAnalysis.Symbols
         //    return builder.ToImmutableAndFree();
         //}
 
-        public sealed override NamedTypeSymbol EnumUnderlyingType
-        {
-            get
-            {
-                return _originalDefinition.EnumUnderlyingType;
-            }
-        }
+        public sealed override NamedTypeSymbol EnumUnderlyingType => _originalDefinition.EnumUnderlyingType;
 
         public override int GetHashCode()
         {
@@ -456,10 +449,7 @@ namespace Pchp.CodeAnalysis.Symbols
             return _hashCode;
         }
 
-        internal sealed override TypeMap TypeSubstitution
-        {
-            get { return this.Map; }
-        }
+        internal sealed override TypeMap TypeSubstitution => this.Map;
 
         //internal sealed override bool IsComImport
         //{
@@ -481,10 +471,7 @@ namespace Pchp.CodeAnalysis.Symbols
             get { return _originalDefinition.IsWindowsRuntimeImport; }
         }
 
-        internal sealed override TypeLayout Layout
-        {
-            get { return _originalDefinition.Layout; }
-        }
+        internal sealed override TypeLayout Layout => _originalDefinition.Layout;
 
         //internal override CharSet MarshallingCharSet
         //{

--- a/src/Peachpie.CodeAnalysis/Symbols/SubstitutedParameterSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/SubstitutedParameterSymbol.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {
@@ -36,11 +31,7 @@ namespace Pchp.CodeAnalysis.Symbols
 
         protected override Symbol OriginalSymbolDefinition => underlyingParameter.OriginalDefinition;
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _containingSymbol; }
-        }
-
+        public override Symbol ContainingSymbol => _containingSymbol;
         internal override TypeSymbol Type
         {
             get

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedCctorSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedCctorSymbol.cs
@@ -1,9 +1,4 @@
 ﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedContainer.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
@@ -1,10 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedFieldSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedFieldSymbol.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
 

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Cci = Microsoft.Cci;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedMethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedMethodSymbol.cs
@@ -1,12 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeGen;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -1,11 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedPropertySymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedPropertySymbol.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Immutable;
 using Microsoft.Cci;
 using Microsoft.CodeAnalysis;
 

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedScriptTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedScriptTypeSymbol.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
 

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedStaticFieldsHolder.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedStaticFieldsHolder.cs
@@ -2,13 +2,9 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Devsense.PHP.Syntax;
 using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
-using System.Threading;
-using Devsense.PHP.Syntax;
-using Devsense.PHP.Syntax.Ast;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedStaticLocHolder.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedStaticLocHolder.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
-using System.Diagnostics;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedTraitFieldSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedTraitFieldSymbol.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Pchp.CodeAnalysis.CodeGen;
+﻿using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedTraitMethodSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedTraitMethodSymbol.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Cci;
 using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Symbols/TypeParameterSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/TypeParameterSymbol.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/TypeParameterSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/TypeParameterSymbol.cs
@@ -23,13 +23,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// If this is a type parameter of a reduced extension method, gets the type parameter definition that
         /// this type parameter was reduced from. Otherwise, returns Nothing.
         /// </summary>
-        public virtual TypeParameterSymbol ReducedFrom
-        {
-            get
-            {
-                return null;
-            }
-        }
+        public virtual TypeParameterSymbol ReducedFrom => null;
 
         /// <summary>
         /// The ordinal position of the type parameter in the parameter list which declares
@@ -53,13 +47,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// Duplicates and cycles are removed, although the collection may include
         /// redundant constraints where one constraint is a base type of another.
         /// </summary>
-        public ImmutableArray<TypeSymbol> ConstraintTypes
-        {
-            get
-            {
-                return this.ConstraintTypesNoUseSiteDiagnostics;
-            }
-        }
+        public ImmutableArray<TypeSymbol> ConstraintTypes => this.ConstraintTypesNoUseSiteDiagnostics;
 
         internal ImmutableArray<TypeSymbol> ConstraintTypesNoUseSiteDiagnostics
         {
@@ -123,13 +111,7 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <summary>
         /// The type that declared this type parameter, or null.
         /// </summary>
-        public NamedTypeSymbol DeclaringType
-        {
-            get
-            {
-                return this.ContainingSymbol as NamedTypeSymbol;
-            }
-        }
+        public NamedTypeSymbol DeclaringType => this.ContainingSymbol as NamedTypeSymbol;
 
         // Type parameters do not have members
         public sealed override ImmutableArray<Symbol> GetMembers()
@@ -161,21 +143,9 @@ namespace Pchp.CodeAnalysis.Symbols
             return ImmutableArray<NamedTypeSymbol>.Empty;
         }
 
-        public sealed override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.TypeParameter;
-            }
-        }
+        public sealed override SymbolKind Kind => SymbolKind.TypeParameter;
 
-        public sealed override TypeKind TypeKind
-        {
-            get
-            {
-                return TypeKind.TypeParameter;
-            }
-        }
+        public sealed override TypeKind TypeKind => TypeKind.TypeParameter;
 
         // Only the compiler can create TypeParameterSymbols.
         internal TypeParameterSymbol()

--- a/src/Peachpie.CodeAnalysis/Symbols/TypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/TypeSymbol.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols

--- a/src/Peachpie.CodeAnalysis/Symbols/TypeSymbolExtensions.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/TypeSymbolExtensions.cs
@@ -1,12 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/TypeWithModifiers.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/TypeWithModifiers.cs
@@ -2,8 +2,8 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/UnboundGenericType.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/UnboundGenericType.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/WellKnownPchpNames.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/WellKnownPchpNames.cs
@@ -1,9 +1,4 @@
 ﻿using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Symbols/WrappedParameterSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/WrappedParameterSymbol.cs
@@ -1,12 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using Roslyn.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Symbols
 {

--- a/src/Peachpie.CodeAnalysis/Syntax/NodesFactory.cs
+++ b/src/Peachpie.CodeAnalysis/Syntax/NodesFactory.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Devsense.PHP.Syntax;
 using Devsense.PHP.Syntax.Ast;
 using Devsense.PHP.Text;

--- a/src/Peachpie.CodeAnalysis/Utilities/AstUtils.cs
+++ b/src/Peachpie.CodeAnalysis/Utilities/AstUtils.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Text;
-using Devsense.PHP.Text;
-using Devsense.PHP.Syntax.Ast;
-using Devsense.PHP.Syntax;
 using System.Diagnostics;
+using System.Linq;
+using Devsense.PHP.Syntax;
+using Devsense.PHP.Syntax.Ast;
+using Devsense.PHP.Text;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Pchp.CodeAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/Utilities/ConstantValueExtensions.cs
+++ b/src/Peachpie.CodeAnalysis/Utilities/ConstantValueExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 
 namespace Pchp.CodeAnalysis

--- a/src/Peachpie.CodeAnalysis/Utilities/Contract.cs
+++ b/src/Peachpie.CodeAnalysis/Utilities/Contract.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/Utilities/DiagnosticBagExtensions.cs
+++ b/src/Peachpie.CodeAnalysis/Utilities/DiagnosticBagExtensions.cs
@@ -1,15 +1,9 @@
-﻿using Devsense.PHP.Syntax.Ast;
+﻿using System.Diagnostics;
+using Devsense.PHP.Syntax.Ast;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Pchp.CodeAnalysis.Errors;
-using Pchp.CodeAnalysis.Semantics;
 using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/Utilities/DistinctQueue.cs
+++ b/src/Peachpie.CodeAnalysis/Utilities/DistinctQueue.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis.Utilities
 {

--- a/src/Peachpie.CodeAnalysis/Utilities/EnumeratorExtension.cs
+++ b/src/Peachpie.CodeAnalysis/Utilities/EnumeratorExtension.cs
@@ -4,9 +4,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.CodeAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/Utilities/ExceptionUtilities.cs
+++ b/src/Peachpie.CodeAnalysis/Utilities/ExceptionUtilities.cs
@@ -1,14 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis;
 using Pchp.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.Semantics;
-using Microsoft.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.Symbols;
-using System.Diagnostics;
 
 namespace Peachpie.CodeAnalysis.Utilities
 {

--- a/src/Peachpie.CodeAnalysis/Utilities/MemberQualifiedName.cs
+++ b/src/Peachpie.CodeAnalysis/Utilities/MemberQualifiedName.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Devsense.PHP.Syntax;
 
 namespace Pchp.CodeAnalysis.Utilities

--- a/src/Peachpie.CodeAnalysis/Utilities/NameUtils.cs
+++ b/src/Peachpie.CodeAnalysis/Utilities/NameUtils.cs
@@ -1,12 +1,9 @@
-﻿using Devsense.PHP.Syntax;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Devsense.PHP.Syntax;
 using Devsense.PHP.Syntax.Ast;
 using Pchp.CodeAnalysis.Symbols;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Diagnostics;
 
 namespace Pchp.CodeAnalysis
 {

--- a/src/Peachpie.CodeAnalysis/Utilities/PhpFileUtilities.cs
+++ b/src/Peachpie.CodeAnalysis/Utilities/PhpFileUtilities.cs
@@ -1,9 +1,6 @@
-﻿using Roslyn.Utilities;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Pchp.CodeAnalysis.Utilities
 {

--- a/src/Peachpie.Runtime/Comparison.cs
+++ b/src/Peachpie.Runtime/Comparison.cs
@@ -198,12 +198,12 @@ namespace Pchp.Core
             if (ReferenceEquals(x, y)) return 0;
 
             // check for different types
-            var type_x = x.GetType().GetTypeInfo();
-            var type_y = y.GetType().GetTypeInfo();
+            var type_x = x.GetType();
+            var type_y = y.GetType();
             if (type_x != type_y)
             {
-                if (type_x.IsSubclassOf(type_y.AsType())) return -1;
-                if (type_y.IsSubclassOf(type_x.AsType())) return 1;
+                if (type_x.IsSubclassOf(type_y)) return -1;
+                if (type_y.IsSubclassOf(type_x)) return 1;
 
                 incomparable = true;
                 return 1; // they really are incomparable

--- a/src/Peachpie.Runtime/Context.ConstsMap.cs
+++ b/src/Peachpie.Runtime/Context.ConstsMap.cs
@@ -1,13 +1,8 @@
-﻿using Pchp.Core.Utilities;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Pchp.Core
 {
@@ -16,7 +11,7 @@ namespace Pchp.Core
         #region ConstName
 
         [DebuggerDisplay("{Name,nq}")]
-        struct ConstName : IEquatable<ConstName>
+        readonly struct ConstName : IEquatable<ConstName>
         {
             public class ConstNameComparer : IEqualityComparer<ConstName>
             {

--- a/src/Peachpie.Runtime/Context.Recursion.cs
+++ b/src/Peachpie.Runtime/Context.Recursion.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Pchp.Core
 {
     partial class Context
     {
-        struct RecursionCheckKey : IEquatable<RecursionCheckKey>
+        readonly struct RecursionCheckKey : IEquatable<RecursionCheckKey>
         {
             public class EqualityComparer : IEqualityComparer<RecursionCheckKey>
             {
@@ -33,7 +31,7 @@ namespace Pchp.Core
             public override bool Equals(object obj) => obj is RecursionCheckKey && Equals((RecursionCheckKey)obj);
         }
 
-        public struct RecursionCheckToken : IDisposable
+        public readonly struct RecursionCheckToken : IDisposable
         {
             readonly Stack<RecursionCheckKey> _list;
             readonly bool _isrecursion;

--- a/src/Peachpie.Runtime/Context.ScriptsMap.cs
+++ b/src/Peachpie.Runtime/Context.ScriptsMap.cs
@@ -40,7 +40,7 @@ namespace Pchp.Core
         /// Script descriptor.
         /// </summary>
         [DebuggerDisplay("{Index}: {Path,nq}")]
-        public struct ScriptInfo : IScript
+        public readonly struct ScriptInfo : IScript
         {
             /// <summary>
             /// Undefined script.
@@ -61,12 +61,12 @@ namespace Pchp.Core
             /// Internal ID.
             /// Index to the internal array of compiled scripts.
             /// </summary>
-            readonly public int Index;
+            public readonly int Index;
 
             /// <summary>
             /// Script path, relative to the <see cref="Context.RootPath"/>.
             /// </summary>
-            readonly public string Path;
+            public readonly string Path;
 
             /// <summary>
             /// Emtry method (main method) of the script.

--- a/src/Peachpie.Runtime/Context.Service.cs
+++ b/src/Peachpie.Runtime/Context.Service.cs
@@ -72,7 +72,7 @@ namespace Pchp.Core
         {
             // Template: return ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(services);
 
-            var t = typeof(ServiceCollectionContainerBuilderExtensions).GetTypeInfo();
+            var t = typeof(ServiceCollectionContainerBuilderExtensions);
             var BuildServiceProviderMethod = t.GetMethod(nameof(BuildServiceProvider), new Type[] { typeof(IServiceCollection) });
             Debug.Assert(BuildServiceProviderMethod != null);
 

--- a/src/Peachpie.Runtime/Dynamic/BinderHelpers.cs
+++ b/src/Peachpie.Runtime/Dynamic/BinderHelpers.cs
@@ -185,8 +185,8 @@ namespace Pchp.Core.Dynamic
             //
 
             var restrictions = target.Restrictions;
-            var lt = target.Expression.Type.GetTypeInfo();
-            if (!lt.IsValueType && !lt.IsSealed && !typeof(PhpArray).IsAssignableFrom(lt.AsType()) && !typeof(PhpResource).IsAssignableFrom(lt.AsType()))
+            var lt = target.Expression.Type;
+            if (!lt.IsValueType && !lt.IsSealed && !typeof(PhpArray).IsAssignableFrom(lt) && !typeof(PhpResource).IsAssignableFrom(lt))
             {
                 // we need to set the type restriction
                 restrictions = restrictions.Merge(BindingRestrictions.GetTypeRestriction(expr, value.GetType()));
@@ -244,8 +244,8 @@ namespace Pchp.Core.Dynamic
         /// </summary>
         internal static bool IsArgumentUnpacking(Expression arg)
         {
-            var tinfo = arg.Type.GetTypeInfo();
-            return tinfo.IsGenericType && tinfo.GetGenericTypeDefinition() == typeof(UnpackingParam<>);
+            var type = arg.Type;
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(UnpackingParam<>);
         }
 
         public static Expression UnpackArgumentsToArray(MethodBase[] methods, Expression[] arguments)
@@ -350,7 +350,7 @@ namespace Pchp.Core.Dynamic
                 else
                 {
                     // getter // TODO: ensure it is not null
-                    Debug.Assert(!expr.Type.GetTypeInfo().IsValueType);
+                    Debug.Assert(!expr.Type.IsValueType);
                 }
             }
             else if (access.EnsureArray())
@@ -484,7 +484,7 @@ namespace Pchp.Core.Dynamic
                     // Template: Operators.IsSet( value )
                     expr = Expression.Call(Cache.Operators.IsSet_PhpValue, expr);
                 }
-                else if (!expr.Type.GetTypeInfo().IsValueType)
+                else if (!expr.Type.IsValueType)
                 {
                     // Template: value != null
                     expr = Expression.ReferenceNotEqual(expr, Expression.Constant(null, typeof(object)));

--- a/src/Peachpie.Runtime/Dynamic/OverloadBinder.cs
+++ b/src/Peachpie.Runtime/Dynamic/OverloadBinder.cs
@@ -971,7 +971,7 @@ namespace Pchp.Core.Dynamic
                     // Template: test = !x.IsDefault
                     test = Expression.Not(Expression.Property(assign, Cache.PhpString.IsDefault));
                 }
-                else if (expr.Type.GetTypeInfo().IsValueType == false)  // reference type
+                else if (expr.Type.IsValueType == false) // reference type
                 {
                     // Template: test = x != null
                     test = Expression.ReferenceNotEqual(assign, Expression.Constant(null, assign.Type));

--- a/src/Peachpie.Runtime/Operators.cs
+++ b/src/Peachpie.Runtime/Operators.cs
@@ -838,12 +838,11 @@ namespace Pchp.Core
                 // TODO: cache following for the enumerable type
 
                 // find IEnumerable<>
-                foreach (var iface_type in enumerable.GetType().GetTypeInfo().GetInterfaces())
+                foreach (var iface_type in enumerable.GetType().GetInterfaces())
                 {
-                    var iface_info = iface_type.GetTypeInfo();
-                    if (iface_info.IsGenericType && iface_info.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                    if (iface_type.IsGenericType && iface_type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
                     {
-                        var item_type = iface_info.GenericTypeArguments[0].GetTypeInfo();
+                        var item_type = iface_type.GenericTypeArguments[0];
                         if (item_type.IsGenericType)
                         {
                             // ValueTuple<A, B>

--- a/src/Peachpie.Runtime/Peachpie.Runtime.csproj
+++ b/src/Peachpie.Runtime/Peachpie.Runtime.csproj
@@ -9,6 +9,7 @@
     <PackageTags>peachpie;runtime</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>Peachpie application runtime.</Description>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Peachpie.CodeAnalysis\Semantics\AccessMask.cs" Link="Dynamic\AccessMask.cs" />

--- a/src/Peachpie.Runtime/PhpValue.cs
+++ b/src/Peachpie.Runtime/PhpValue.cs
@@ -459,7 +459,7 @@ namespace Pchp.Core
             if (type == typeof(string)) return this.ToString();
             if (type == typeof(object)) return this.ToClass();
 
-            if (this.Object != null && type.GetTypeInfo().IsAssignableFrom(this.Object.GetType()))
+            if (this.Object != null && type.IsAssignableFrom(this.Object.GetType()))
             {
                 return this.Object;
             }

--- a/src/Peachpie.Runtime/Reflection/ExtensionsTable.cs
+++ b/src/Peachpie.Runtime/Reflection/ExtensionsTable.cs
@@ -137,7 +137,7 @@ namespace Pchp.Core.Reflection
 
             foreach (var m in routine.Methods)
             {
-                var tinfo = m.DeclaringType.GetTypeInfo();
+                var tinfo = m.DeclaringType;
 
                 //
                 var extinfo = tinfo.GetCustomAttribute<PhpExtensionAttribute>();

--- a/src/Peachpie.Runtime/Reflection/PhpStackTrace.cs
+++ b/src/Peachpie.Runtime/Reflection/PhpStackTrace.cs
@@ -144,7 +144,7 @@ namespace Pchp.Core.Reflection
             }
 
             // <Script> type
-            var tinfo = method.DeclaringType.GetTypeInfo();
+            var tinfo = method.DeclaringType;
             if (tinfo.Name == "<Script>")
             {
                 return false;
@@ -267,7 +267,7 @@ namespace Pchp.Core.Reflection
             get
             {
                 var method = _clrframe.GetMethod();
-                var tinfo = method.DeclaringType.GetTypeInfo();
+                var tinfo = method.DeclaringType;
 
                 if (method.IsStatic)
                 {

--- a/src/Peachpie.Runtime/Reflection/PhpTypeInfo.cs
+++ b/src/Peachpie.Runtime/Reflection/PhpTypeInfo.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Pchp.Core.Reflection
 {
@@ -112,8 +110,7 @@ namespace Pchp.Core.Reflection
 
                 if (_lazyCreatorProtected == null || _lazyCreatorProtected != _lazyCreator) // in case protected creator == public creator, we can skip following checks
                 {
-                    var callerinfo = caller.GetTypeInfo();
-                    if (callerinfo.IsAssignableFrom(_type) || _type.IsAssignableFrom(callerinfo))
+                    if (caller.IsAssignableFrom(_type) || _type.IsAssignableFrom(caller))
                     {
                         // creation including protected|public .ctors
                         return this.Creator_protected;
@@ -375,7 +372,7 @@ namespace Pchp.Core.Reflection
             // invoke GetPhpTypeInfo<TType>() dynamically and cache the result
             if (result == null)
             {
-                if (type.GetTypeInfo().IsGenericTypeDefinition)
+                if (type.IsGenericTypeDefinition)
                 {
                     // generic type definition cannot be used as a type parameter for GetPhpTypeInfo<T>
                     // just instantiate the type info and cache the result

--- a/src/Peachpie.Runtime/Reflection/ReflectionUtils.cs
+++ b/src/Peachpie.Runtime/Reflection/ReflectionUtils.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Pchp.Core.Dynamic;
 
 namespace Pchp.Core.Reflection
@@ -74,13 +72,12 @@ namespace Pchp.Core.Reflection
         /// <summary>
         /// Gets value indicating the given type is a type of a class instance excluding builtin PHP value types.
         /// </summary>
-        public static bool IsPhpClassType(TypeInfo tinfo)
+        public static bool IsPhpClassType(Type type)
         {
-            Debug.Assert(tinfo != null);
-            Debug.Assert(tinfo.AsType() != typeof(PhpAlias));
+            Debug.Assert(type != null);
+            Debug.Assert(type != typeof(PhpAlias));
 
-            var t = tinfo.AsType();
-            return !tinfo.IsValueType && t != typeof(PhpArray) && t != typeof(string) && t != typeof(IPhpCallable);
+            return !type.IsValueType && type != typeof(PhpArray) && type != typeof(string) && type != typeof(IPhpCallable);
         }
 
         readonly static HashSet<Type> s_hiddenTypes = new HashSet<Type>()
@@ -88,7 +85,7 @@ namespace Pchp.Core.Reflection
             typeof(object),
             typeof(IPhpCallable),
             typeof(PhpResource),
-            typeof(System.Exception),
+            typeof(Exception),
             typeof(System.Dynamic.IDynamicMetaObjectProvider),
             typeof(IPhpConvertible),
             typeof(IPhpComparable),

--- a/src/Peachpie.Runtime/Reflection/TypeMembersUtils.cs
+++ b/src/Peachpie.Runtime/Reflection/TypeMembersUtils.cs
@@ -339,7 +339,7 @@ namespace Pchp.Core.Reflection
         {
             Debug.Assert(memberctx != null);
 
-            return caller != null && memberctx.GetTypeInfo().IsAssignableFrom(caller);
+            return caller != null && memberctx.IsAssignableFrom(caller);
         }
 
         /// <summary>
@@ -365,10 +365,9 @@ namespace Pchp.Core.Reflection
                 }
                 else
                 {
-                    var m_type = ((MethodInfo)m).GetBaseDefinition().DeclaringType.GetTypeInfo();
-                    var classCtx_type = classCtx.GetTypeInfo();
+                    var m_type = ((MethodInfo)m).GetBaseDefinition().DeclaringType;
 
-                    return classCtx_type.IsAssignableFrom(m_type) || m_type.IsAssignableFrom(classCtx_type);
+                    return classCtx.IsAssignableFrom(m_type) || m_type.IsAssignableFrom(classCtx);
                 }
             }
 

--- a/src/Peachpie.Runtime/Utilities/ContextExtensions.cs
+++ b/src/Peachpie.Runtime/Utilities/ContextExtensions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Reflection;
 
 namespace Pchp.Core.Utilities
 {
@@ -17,7 +12,7 @@ namespace Pchp.Core.Utilities
         /// </summary>
         public static string GetRuntimeInformationalVersion()
         {
-            return typeof(Context).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            return typeof(Context).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
         }
 
         /// <summary>

--- a/src/Tests/Peachpie.DiagnosticTests/Peachpie.DiagnosticTests.csproj
+++ b/src/Tests/Peachpie.DiagnosticTests/Peachpie.DiagnosticTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,10 +16,6 @@
     <ProjectReference Include="..\..\Peachpie.Library.Scripting\Peachpie.Library.Scripting.csproj" />
     <ProjectReference Include="..\..\Peachpie.Library\Peachpie.Library.csproj" />
     <ProjectReference Include="..\..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Peachpie.Runtime.Tests/Peachpie.Runtime.Tests.csproj
+++ b/src/Tests/Peachpie.Runtime.Tests/Peachpie.Runtime.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,10 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Peachpie.ScriptTests/Peachpie.ScriptTests.csproj
+++ b/src/Tests/Peachpie.ScriptTests/Peachpie.ScriptTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks> 
+    <TargetFramework>netcoreapp2.1</TargetFramework> 
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Peachpie.Test/Peachpie.Test.csproj
+++ b/src/Tests/Peachpie.Test/Peachpie.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Removes the unneeded calls to GetTypeInfo() without changing any behaviors
- Remove and sort using statements
- Use expression bodies for simple properties
- Annotate a few readonly structs
- Use pattern matching
- Updates lang version to 7.2
- Updates travis image to dotnet v2.1