### PR TITLE
Switch to MySqlConnector

### DIFF
--- a/src/PDO/Peachpie.Library.PDO.MySQL/Peachpie.Library.PDO.MySQL.csproj
+++ b/src/PDO/Peachpie.Library.PDO.MySQL/Peachpie.Library.PDO.MySQL.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySql.Data" Version="8.0.11" />
+    <PackageReference Include="MySqlConnector" Version="0.42.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Peachpie.Library.MySql/MySql.Functions.cs
+++ b/src/Peachpie.Library.MySql/MySql.Functions.cs
@@ -147,7 +147,7 @@ namespace Peachpie.Library.MySql
             var config = ctx.Configuration.Get<MySqlConfiguration>();
             Debug.Assert(config != null);
 
-            var connection_string = BuildConnectionString(config, ref server, username, password, (ConnectFlags)client_flags, characterset: "utf8mb4");
+            var connection_string = BuildConnectionString(config, ref server, username, password, (ConnectFlags)client_flags);
 
             bool success;
             var connection = MySqlConnectionManager.GetInstance(ctx)
@@ -179,7 +179,7 @@ namespace Peachpie.Library.MySql
             return mysql_connect(ctx, server, username, password, new_link, client_flags);
         }
 
-        internal static string BuildConnectionString(MySqlConfiguration config, ref string server, string user, string password, ConnectFlags flags, int connectiontimeout = 0, string characterset = null)
+        internal static string BuildConnectionString(MySqlConfiguration config, ref string server, string user, string password, ConnectFlags flags, int connectiontimeout = 0)
         {
             // connection strings:
             if (server == null && user == null && password == null && flags == ConnectFlags.None && !string.IsNullOrEmpty(config.ConnectionString))
@@ -202,11 +202,11 @@ namespace Peachpie.Library.MySql
             if (user == null) user = config.User;
             if (password == null) password = config.Password;
 
-            // build the connection string to be used with MySQL Connector/.NET
-            // see http://dev.mysql.com/doc/refman/5.5/en/connector-net-connection-options.html
+            // build the connection string to be used with MySqlConnector
+            // see https://mysql-net.github.io/MySqlConnector/connection-options/ and http://dev.mysql.com/doc/refman/5.5/en/connector-net-connection-options.html
             return BuildConnectionString(
               server, user, password,
-              string.Format("allowzerodatetime=true;allow user variables=true;connect timeout={0};Port={1};SSL Mode={2};Use Compression={3}{4}{5};Max Pool Size={6}{7}{8}",
+              string.Format("allowzerodatetime=true;allow user variables=true;connect timeout={0};Port={1};SSL Mode={2};Use Compression={3}{4}{5};Max Pool Size={6}{7}",
                 (connectiontimeout > 0) ? connectiontimeout : (config.ConnectTimeout > 0) ? config.ConnectTimeout : 15,
                 port,
                 (flags & ConnectFlags.SSL) != 0 ? "Preferred" : "None",     // (since Connector 6.2.1.) ssl mode={None|Preferred|Required|VerifyCA|VerifyFull}   // (Jakub) use ssl={true|false} has been deprecated
@@ -214,8 +214,7 @@ namespace Peachpie.Library.MySql
                 (pipe_name != null) ? ";Pipe=" + pipe_name : null,  // Pipe={...}
                 (flags & ConnectFlags.Interactive) != 0 ? ";Interactive=true" : null,    // Interactive={true|false}
                 config.MaxPoolSize,                                          // Max Pool Size=100
-                (config.DefaultCommandTimeout >= 0) ? ";DefaultCommandTimeout=" + config.DefaultCommandTimeout : null,
-                string.IsNullOrEmpty(characterset) ? null : ";characterset="+ characterset
+                (config.DefaultCommandTimeout >= 0) ? ";DefaultCommandTimeout=" + config.DefaultCommandTimeout : null
                 )
             );
         }

--- a/src/Peachpie.Library.MySql/MySqli/mysqli.cs
+++ b/src/Peachpie.Library.MySql/MySqli/mysqli.cs
@@ -280,13 +280,11 @@ namespace Peachpie.Library.MySql.MySqli
         {
             var config = ctx.Configuration.Get<MySqlConfiguration>();
             int connectiontimeout = 0;
-            string characterset = "utf8mb4"; // default characterset that solves all the problems
 
             if (_lazyoptions != null)
             {
                 PhpValue value;
                 if (_lazyoptions.TryGetValue(Constants.MYSQLI_OPT_CONNECT_TIMEOUT, out value)) connectiontimeout = (int)value.ToLong();
-                if (_lazyoptions.TryGetValue(Constants.MYSQLI_SET_CHARSET_NAME, out value)) characterset = value.ToStringOrThrow(ctx);
             }
 
             // string $host = ini_get("mysqli.default_host")
@@ -298,8 +296,7 @@ namespace Peachpie.Library.MySql.MySqli
 
             var connection_string = MySql.BuildConnectionString(config, ref host, username, passwd,
                 flags: (MySql.ConnectFlags)flags,
-                connectiontimeout: connectiontimeout,
-                characterset: characterset);
+                connectiontimeout: connectiontimeout);
 
             _connection = MySqlConnectionManager.GetInstance(ctx)
                 .CreateConnection(connection_string, false, -1, out bool success);

--- a/src/Peachpie.Library.MySql/Peachpie.Library.MySql.csproj
+++ b/src/Peachpie.Library.MySql/Peachpie.Library.MySql.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Peachpie.Library\Peachpie.Library.csproj" />
     <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
-    <PackageReference Include="MySql.Data" Version="8.0.11" />
+    <PackageReference Include="MySqlConnector" Version="0.42.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This repeats the switch to MySqlConnector originally made in #209, which was backed out in af1893fb9759818ecc0c0ae41ae40e479274331a due to incompatibility.

MySqlConnector 0.42.0 now supports the following connection string options, which were required by this code:
* `AllowZeroDateTime` mysql-net/MySqlConnector#507
* `Interactive` mysql-net/MySqlConnector#510
* `Pipe` mysql-net/MySqlConnector#454

~~I ran the TechEmpower Framework benchmarks locally and got the same number of requests per second before and after this change, so unfortunately it doesn't look like it'll bring an immediate performance improvements,~~ but it does [fix a lot of bugs](https://mysql-net.github.io/MySqlConnector/tutorials/migrating-from-connector-net/#fixed-bugs) in the ADO.NET driver.

_Edit:_ apparently the way I'm building the TFB benchmarks isn't bringing in MySqlConnector, which explains why performance was exactly the same...