### PR TITLE
automatically provide Peachpie.Library.PDO.MySQL as dev package to nuget

### DIFF
--- a/build/dummy/dummy.msbuildproj
+++ b/build/dummy/dummy.msbuildproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Peachpie.NET.Sdk" Version="$(VersionPrefix)-$(VersionSuffix)" PrivateAssets="Build" />
 	<PackageReference Include="Peachpie.NETCore.Web" Version="$(VersionPrefix)-$(VersionSuffix)" PrivateAssets="Build" />
 	<PackageReference Include="Peachpie.Library.PDO" Version="$(VersionPrefix)-$(VersionSuffix)" PrivateAssets="Build" />
+        <PackageReference Include="Peachpie.Library.PDO.MySQL" Version="$(VersionPrefix)-$(VersionSuffix)" PrivateAssets="Build" />
 	<PackageReference Include="Peachpie.Library.Graphics" Version="$(VersionPrefix)-$(VersionSuffix)" PrivateAssets="Build" />
 	<PackageReference Include="Peachpie.Library.Network" Version="$(VersionPrefix)-$(VersionSuffix)" PrivateAssets="Build" />
     <DotNetCliToolReference Include="Peachpie.Compiler.Tools" Version="$(VersionPrefix)-$(VersionSuffix)" />

--- a/build/update-cache.ps1
+++ b/build/update-cache.ps1
@@ -13,7 +13,7 @@ $defaultArgs = "/p:VersionPrefix=$version,VersionSuffix=$suffix"
 
 ## Delete old nuget packages
 Write-Host -f green "Deleting '$version-$suffix' packages from '$packagesSource' ..."
-@("Peachpie.Runtime", "Peachpie.Library", "Peachpie.Library.Scripting", "Peachpie.Library.MySql", "Peachpie.Library.MsSql", "Peachpie.Library.Graphics", "Peachpie.Library.Network", "Peachpie.Library.PDO", "Peachpie.Library.XmlDom", "Peachpie.App", "Peachpie.CodeAnalysis", "Peachpie.NETCore.Web", "Peachpie.Compiler.Tools", "Peachpie.NET.Sdk") | % {
+@("Peachpie.Runtime", "Peachpie.Library", "Peachpie.Library.Scripting", "Peachpie.Library.MySql", "Peachpie.Library.MsSql", "Peachpie.Library.Graphics", "Peachpie.Library.Network", "Peachpie.Library.PDO", "Peachpie.Library.XmlDom", "Peachpie.App", "Peachpie.CodeAnalysis", "Peachpie.NETCore.Web", "Peachpie.Compiler.Tools", "Peachpie.NET.Sdk", "Peachpie.Library.PDO.MySql") | % {
 	$installedFolder = "$packagesSource/$_/$version-$suffix"
     if (Test-Path $installedFolder) {
         Remove-Item -Recurse -Force $installedFolder


### PR DESCRIPTION
I noticed that running `build\update-cache.ps1 0.9.0` did not update Peachpie.Library.PDO.MySQL so I changed it to do this. 
I noticed there also exists Library.MsSQL and I assume PDO.MsSQL is present, too. But scince I'm not familiar with msbuild and I currently have no case to test this I omitted it to do no harm.