### PR TITLE
Enable analysis in parallel

### DIFF
--- a/src/Peachpie.CodeAnalysis/Compilation/SourceCompiler.cs
+++ b/src/Peachpie.CodeAnalysis/Compilation/SourceCompiler.cs
@@ -153,7 +153,7 @@ namespace Pchp.CodeAnalysis
             // LowerBody(block)
 
             // analyse blocks
-            _worklist.DoAll(concurrent: false/*TODO: ConcurrentBuild*/);
+            _worklist.DoAll(concurrent: ConcurrentBuild);
         }
 
         void AnalyzeBlock(BoundBlock block) // TODO: driver


### PR DESCRIPTION
Dequeue at most one block per routine in analysis batch - it solves the race conditions on `FlowContext` and also it speeds up the analysis even in the serial case (e.g. about 10% for WordPress).