### PR TITLE
Fix adding unnecessary void to routine return type in analysis

### DIFF
--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/ExpressionAnalysis.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/ExpressionAnalysis.cs
@@ -2109,7 +2109,8 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
             else
             {
                 // remember "void" type explicitly
-                State.FlowThroughReturn(0);
+                var voidMask = State.TypeRefContext.GetTypeMask(TypeRefFactory.VoidTypeRef, false); // NOTE: or remember the routine may return Void
+                State.FlowThroughReturn(voidMask);
             }
         }
 

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/FlowState.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/FlowState.cs
@@ -290,11 +290,6 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
 
         public void FlowThroughReturn(TypeRefMask type)
         {
-            if (type.IsVoid)
-            {
-                type = this.TypeRefContext.GetTypeMask(TypeRefFactory.VoidTypeRef, false);  // NOTE: or remember the routine may return Void
-            }
-
             _flowCtx.ReturnType |= type;
         }
 

--- a/src/Tests/Peachpie.DiagnosticTests/tests/recursion_02.php
+++ b/src/Tests/Peachpie.DiagnosticTests/tests/recursion_02.php
@@ -1,18 +1,18 @@
 <?php
 
 function pad_left(string $a) {
-    if (strlen($a) < 5) {
-        return $a;
-    } else {
+    if (strlen($a) >= 5) {
         return pad_right(substr($a, 1));
+    } else {
+        return $a;
     }
 }
 
 function pad_right(string $a) {
-    if (strlen($a) < 5) {
-        return $a;
-    } else {
+    if (strlen($a) >= 5) {
         return pad_left(substr($a, 0, strlen($a) - 1));
+    } else {
+        return $a;
     }
 }
 

--- a/src/Tests/Peachpie.DiagnosticTests/tests/type_analysis_06.php
+++ b/src/Tests/Peachpie.DiagnosticTests/tests/type_analysis_06.php
@@ -1,0 +1,11 @@
+<?php
+
+function foo($x) {
+  if ($x) {
+    return true;
+  } else {
+    return;
+  }
+}
+
+/*|boolean|void|*/$res = foo(42);


### PR DESCRIPTION
It used to happen when an empty type mask from an uninitialized routine was used as a returned value. Update this so that void is not added in this case.