### PR TITLE
Enable removing unreachable functions and types using semantic transformations

### DIFF
--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Convert.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Convert.cs
@@ -1301,6 +1301,8 @@ namespace Pchp.CodeAnalysis.CodeGen
             Contract.ThrowIfNull(from);
             Contract.ThrowIfNull(to);
 
+            Debug.Assert(!from.IsUnreachable);
+            Debug.Assert(!to.IsUnreachable);
             Debug.Assert(!to.IsErrorType(), "Conversion to an error type.");
 
             // conversion is not needed:

--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
@@ -317,6 +317,8 @@ namespace Pchp.CodeAnalysis.CodeGen
         /// <returns>New type on top of evaluation stack.</returns>
         internal TypeSymbol EmitSpecialize(TypeSymbol stack, TypeRefMask tmask)
         {
+            Debug.Assert(!stack.IsUnreachable);
+
             // specialize type if possible
             if (tmask.IsSingleType && !tmask.IsRef)
             {
@@ -469,6 +471,7 @@ namespace Pchp.CodeAnalysis.CodeGen
         /// </summary>
         public void EmitNotNull(TypeSymbol t, TypeRefMask tmask)
         {
+            Debug.Assert(!t.IsUnreachable);
             // CanBeNull(tmask)
             // CanBeNull(t)
 
@@ -508,6 +511,7 @@ namespace Pchp.CodeAnalysis.CodeGen
         public void EmitFieldAddress(FieldSymbol fld)
         {
             Debug.Assert(fld != null);
+
             _il.EmitOpCode(fld.IsStatic ? ILOpCode.Ldsflda : ILOpCode.Ldflda);
             EmitSymbolToken(fld, null);
         }
@@ -2322,6 +2326,9 @@ namespace Pchp.CodeAnalysis.CodeGen
 
         internal TypeSymbol EmitCastClass(TypeSymbol from, TypeSymbol to)
         {
+            Debug.Assert(!from.IsUnreachable);
+            Debug.Assert(!to.IsUnreachable);
+
             if (from.IsOfType(to))
             {
                 return from;
@@ -2335,6 +2342,8 @@ namespace Pchp.CodeAnalysis.CodeGen
 
         internal void EmitCastClass(TypeSymbol type)
         {
+            Debug.Assert(!type.IsUnreachable);
+
             // (T)
             _il.EmitOpCode(ILOpCode.Castclass);
             EmitSymbolToken(type, null);
@@ -2574,6 +2583,7 @@ namespace Pchp.CodeAnalysis.CodeGen
         public void EmitDeclareFunction(SourceFunctionSymbol f)
         {
             Debug.Assert(f != null);
+            Debug.Assert(!f.IsUnreachable);
 
             var field = f.EnsureRoutineInfoField(_moduleBuilder);
 
@@ -2648,6 +2658,7 @@ namespace Pchp.CodeAnalysis.CodeGen
         public void EmitExpectTypeDeclared(TypeSymbol d)
         {
             Debug.Assert(d.IsValidType());
+            Debug.Assert(!d.IsUnreachable);
 
             if (d is NamedTypeSymbol ntype)
             {
@@ -2701,6 +2712,8 @@ namespace Pchp.CodeAnalysis.CodeGen
             var dependent = new Dictionary<QualifiedName, HashSet<NamedTypeSymbol>>();
             foreach (var v in versions)
             {
+                Debug.Assert(!v.IsUnreachable);
+
                 var deps = v.GetDependentSourceTypeSymbols(); // TODO: error when the type version reports it depends on a user type which will never be declared because of a library type
                 foreach (var d in deps.OfType<IPhpTypeSymbol>())
                 {
@@ -2814,6 +2827,8 @@ namespace Pchp.CodeAnalysis.CodeGen
 
             foreach (var h in types)
             {
+                Debug.Assert(!h.IsUnreachable);
+
                 if (lblElse != null) _il.MarkLabel(lblElse);
 
                 // Template: if (thandle.Equals(h)) { ... } else goto lblElse;

--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
@@ -2598,13 +2598,23 @@ namespace Pchp.CodeAnalysis.CodeGen
             this.EmitSequencePoint(t.Syntax.HeadingSpan);
 
             // autoload base types or throw an error
-            if (t.HasVersions)
+            var versions = t.HasVersions ? t.AllReachableVersions() : default;
+            if (!versions.IsDefault && versions.Length > 1)
             {
                 // emit declaration of type that has ambiguous versions
-                EmitVersionedTypeDeclaration(t.AllVersions());
+                EmitVersionedTypeDeclaration(versions);
             }
             else
             {
+                // Ensure to emit only reachable type
+                if (t.HasVersions)
+                {
+                    // TODO: Error when all the ancestors have been eliminated
+                    Debug.Assert(versions.Length == 1);
+                    t = versions[0];
+                }
+                Debug.Assert(!t.IsUnreachable);
+                
                 var dependent = t.GetDependentSourceTypeSymbols();
 
                 // ensure all types are loaded into context,

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundExpression.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundExpression.cs
@@ -2393,6 +2393,7 @@ namespace Pchp.CodeAnalysis.Semantics
 
             if (TargetMethod.IsValidMethod())
             {
+                Debug.Assert(!TargetMethod.IsUnreachable);
                 // the most preferred case when method is known,
                 // the method can be called directly
                 return EmitDirectCall(cg, IsVirtualCall ? ILOpCode.Callvirt : ILOpCode.Call, TargetMethod, LateStaticTypeRef);

--- a/src/Peachpie.CodeAnalysis/Compilation/SourceCompiler.cs
+++ b/src/Peachpie.CodeAnalysis/Compilation/SourceCompiler.cs
@@ -226,7 +226,9 @@ namespace Pchp.CodeAnalysis
 
             this.WalkMethods(m =>
                 {
-                    anyTransforms |= TransformationRewriter.TryTransform(m);
+                    // Cannot be simplified due to multithreading ('=' is atomic unlike '|=')
+                    if (TransformationRewriter.TryTransform(m))
+                        anyTransforms = true;
                 },
                 allowParallel: allowParallel);
 

--- a/src/Peachpie.CodeAnalysis/Compilation/SourceCompiler.cs
+++ b/src/Peachpie.CodeAnalysis/Compilation/SourceCompiler.cs
@@ -223,14 +223,18 @@ namespace Pchp.CodeAnalysis
         bool TransformMethods(bool allowParallel)
         {
             bool anyTransforms = false;
+            var delayedTrn = new DelayedTransformations();
 
             this.WalkMethods(m =>
                 {
                     // Cannot be simplified due to multithreading ('=' is atomic unlike '|=')
-                    if (TransformationRewriter.TryTransform(m))
+                    if (TransformationRewriter.TryTransform(delayedTrn, m))
                         anyTransforms = true;
                 },
                 allowParallel: allowParallel);
+
+            // Apply transformation that cannot run in the parallel way
+            delayedTrn.Apply();
 
             return anyTransforms;
         }

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/Passes/DelayedTransformations.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/Passes/DelayedTransformations.cs
@@ -18,11 +18,21 @@ namespace Pchp.CodeAnalysis.FlowAnalysis.Passes
         /// </summary>
         public ConcurrentBag<SourceRoutineSymbol> UnreachableRoutines { get; } = new ConcurrentBag<SourceRoutineSymbol>();
 
+        /// <summary>
+        /// Types with unreachable declarations.
+        /// </summary>
+        public ConcurrentBag<SourceTypeSymbol> UnreachableTypes { get; } = new ConcurrentBag<SourceTypeSymbol>();
+
         public void Apply()
         {
             foreach (var routine in UnreachableRoutines)
             {
                 routine.Flags |= RoutineFlags.IsUnreachable;
+            }
+
+            foreach (var type in UnreachableTypes)
+            {
+                type.IsMarkedUnreachable = true;
             }
         }
     }

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/Passes/DelayedTransformations.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/Passes/DelayedTransformations.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+using Pchp.CodeAnalysis;
+using Pchp.CodeAnalysis.FlowAnalysis;
+using Pchp.CodeAnalysis.Symbols;
+
+namespace Pchp.CodeAnalysis.FlowAnalysis.Passes
+{
+    /// <summary>
+    /// Stores certain types of transformations in parallel fashion and performs them serially afterwards.
+    /// </summary>
+    internal class DelayedTransformations
+    {
+        /// <summary>
+        /// Routines with unreachable declarations.
+        /// </summary>
+        public ConcurrentBag<SourceRoutineSymbol> UnreachableRoutines { get; } = new ConcurrentBag<SourceRoutineSymbol>();
+
+        public void Apply()
+        {
+            foreach (var routine in UnreachableRoutines)
+            {
+                routine.Flags |= RoutineFlags.IsUnreachable;
+            }
+        }
+    }
+}

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/Passes/TransformationRewriter.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/Passes/TransformationRewriter.cs
@@ -50,6 +50,11 @@ namespace Pchp.CodeAnalysis.FlowAnalysis.Passes
             _delayedTransformations.UnreachableRoutines.Add(routine);
         }
 
+        private protected override void OnUnreachableTypeFound(SourceTypeSymbol type)
+        {
+            _delayedTransformations.UnreachableTypes.Add(type);
+        }
+
         public override object VisitConditional(BoundConditionalEx x)
         {
             x = (BoundConditionalEx)base.VisitConditional(x);

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/Passes/TransformationRewriter.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/Passes/TransformationRewriter.cs
@@ -10,11 +10,12 @@ namespace Pchp.CodeAnalysis.FlowAnalysis.Passes
 {
     internal class TransformationRewriter : GraphRewriter
     {
+        private readonly DelayedTransformations _delayedTransformations;
         private readonly SourceRoutineSymbol _routine;
 
         public int TransformationCount { get; private set; }
 
-        public static bool TryTransform(SourceRoutineSymbol routine)
+        public static bool TryTransform(DelayedTransformations delayedTransformations, SourceRoutineSymbol routine)
         {
             if (routine.ControlFlowGraph == null)
             {
@@ -23,7 +24,7 @@ namespace Pchp.CodeAnalysis.FlowAnalysis.Passes
             }
 
             //
-            var rewriter = new TransformationRewriter(routine);
+            var rewriter = new TransformationRewriter(delayedTransformations, routine);
             var currentCFG = routine.ControlFlowGraph;
             var updatedCFG = (ControlFlowGraph)rewriter.VisitCFG(currentCFG);
 
@@ -33,14 +34,20 @@ namespace Pchp.CodeAnalysis.FlowAnalysis.Passes
             return updatedCFG != currentCFG;
         }
 
-        private TransformationRewriter(SourceRoutineSymbol routine)
+        private TransformationRewriter(DelayedTransformations delayedTransformations, SourceRoutineSymbol routine)
         {
+            _delayedTransformations = delayedTransformations;
             _routine = routine;
         }
 
         protected override void OnVisitCFG(ControlFlowGraph x)
         {
             Debug.Assert(_routine.ControlFlowGraph == x);
+        }
+
+        private protected override void OnUnreachableRoutineFound(SourceRoutineSymbol routine)
+        {
+            _delayedTransformations.UnreachableRoutines.Add(routine);
         }
 
         public override object VisitConditional(BoundConditionalEx x)

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/RoutineFlags.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/RoutineFlags.cs
@@ -35,6 +35,11 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
         HasUserFunctionCall = 128,
 
         /// <summary>
+        /// Indicates that the routine declaration was proven unreachable during the analysis.
+        /// </summary>
+        IsUnreachable = 256,
+
+        /// <summary>
         /// Whether the routine has to define local variables as an array instead of native local variables.
         /// </summary>
         RequiresLocalsArray = HasEval | HasInclude | HasIndirectVar | UsesLocals | IsGenerator,

--- a/src/Peachpie.CodeAnalysis/Semantics/Graph/GraphRewriter.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Graph/GraphRewriter.cs
@@ -123,6 +123,13 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
 
                 return base.VisitFunctionDeclaration(x);
             }
+
+            public override VoidStruct VisitTypeDeclaration(BoundTypeDeclStatement x)
+            {
+                _rewriter.OnUnreachableTypeFound(x.DeclaredType);
+
+                return base.VisitTypeDeclaration(x);
+            }
         }
 
         #endregion
@@ -337,6 +344,9 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
         #endregion
 
         protected private virtual void OnUnreachableRoutineFound(SourceRoutineSymbol routine)
+        { }
+
+        protected private virtual void OnUnreachableTypeFound(SourceTypeSymbol type)
         { }
     }
 }

--- a/src/Peachpie.CodeAnalysis/Symbols/Php/PhpRoutineSymbolExtensions.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Php/PhpRoutineSymbolExtensions.cs
@@ -304,7 +304,7 @@ namespace Pchp.CodeAnalysis.Symbols
             var funcs = file.Functions.Cast<SourceRoutineSymbol>();
             var main = (SourceRoutineSymbol)file.MainMethod;
 
-            var types = file.ContainedTypes.SelectMany(t => t.AllVersions());
+            var types = file.ContainedTypes.SelectMany(t => t.AllReachableVersions());
             var methods = types.SelectMany(f => f.GetMembers().OfType<SourceRoutineSymbol>());
             var lambdas = ((ILambdaContainerSymbol)file).Lambdas;
 

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFileSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFileSymbol.cs
@@ -265,7 +265,7 @@ namespace Pchp.CodeAnalysis.Symbols
             var builder = ImmutableArray.CreateBuilder<Symbol>(1 + _lazyMembers.Count);
 
             builder.Add(_mainMethod);
-            builder.AddRange(_lazyMembers.Where(s => !s.IsUnreachable));
+            builder.AddRange(_lazyMembers);
 
             return builder.ToImmutable();
         }
@@ -278,14 +278,14 @@ namespace Pchp.CodeAnalysis.Symbols
             }
 
             return _lazyMembers
-                .Where(x => x.Name == name && !x.IsUnreachable)
+                .Where(x => x.Name == name)
                 .ToImmutableArray();
         }
 
         public override ImmutableArray<Symbol> GetMembersByPhpName(string name)
         {
             return _lazyMembers
-                .Where(x => x.Name.StringsEqual(name, ignoreCase: true) && !x.IsUnreachable)
+                .Where(x => x.Name.StringsEqual(name, ignoreCase: true))
                 .ToImmutableArray();
         }
 
@@ -298,6 +298,11 @@ namespace Pchp.CodeAnalysis.Symbols
         internal override IEnumerable<IFieldSymbol> GetFieldsToEmit() => GetMembers().OfType<FieldSymbol>();
 
         internal override ImmutableArray<NamedTypeSymbol> GetInterfacesToEmit() => ImmutableArray<NamedTypeSymbol>.Empty;
+
+        internal override IEnumerable<IMethodSymbol> GetMethodsToEmit() =>
+            GetMembers()
+            .Where(m => m.Kind == SymbolKind.Method && !m.IsUnreachable)
+            .Cast<IMethodSymbol>();
     }
 
     /// <summary>

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFileSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFileSymbol.cs
@@ -34,10 +34,12 @@ namespace Pchp.CodeAnalysis.Symbols
 
         BaseAttributeData _lazyScriptAttribute;
 
+        private IEnumerable<Symbol> ReachableMembers => _lazyMembers.Where(m => !m.IsUnreachable);
+
         /// <summary>
         /// List of functions declared within the file.
         /// </summary>
-        public ImmutableArray<SourceFunctionSymbol> Functions => _lazyMembers.OfType<SourceFunctionSymbol>().ToImmutableArray();
+        public ImmutableArray<SourceFunctionSymbol> Functions => ReachableMembers.OfType<SourceFunctionSymbol>().ToImmutableArray();
 
         /// <summary>
         /// List of types declared within the file.
@@ -89,7 +91,7 @@ namespace Pchp.CodeAnalysis.Symbols
         {
             get
             {
-                return _lazyMembers.OfType<SourceLambdaSymbol>();
+                return ReachableMembers.OfType<SourceLambdaSymbol>();
             }
         }
 
@@ -265,7 +267,7 @@ namespace Pchp.CodeAnalysis.Symbols
             var builder = ImmutableArray.CreateBuilder<Symbol>(1 + _lazyMembers.Count);
 
             builder.Add(_mainMethod);
-            builder.AddRange(_lazyMembers);
+            builder.AddRange(ReachableMembers);
 
             return builder.ToImmutable();
         }
@@ -277,23 +279,23 @@ namespace Pchp.CodeAnalysis.Symbols
                 return ImmutableArray.Create<Symbol>(_mainMethod);
             }
 
-            return _lazyMembers
+            return ReachableMembers
                 .Where(x => x.Name == name)
                 .ToImmutableArray();
         }
 
         public override ImmutableArray<Symbol> GetMembersByPhpName(string name)
         {
-            return _lazyMembers
+            return ReachableMembers
                 .Where(x => x.Name.StringsEqual(name, ignoreCase: true))
                 .ToImmutableArray();
         }
 
         public override ImmutableArray<MethodSymbol> StaticConstructors => ImmutableArray<MethodSymbol>.Empty;
 
-        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers() => _lazyMembers.OfType<NamedTypeSymbol>().AsImmutable();
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers() => ReachableMembers.OfType<NamedTypeSymbol>().AsImmutable();
 
-        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name) => _lazyMembers.OfType<NamedTypeSymbol>().Where(t => t.Name.Equals(name, StringComparison.OrdinalIgnoreCase)).AsImmutable();
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name) => ReachableMembers.OfType<NamedTypeSymbol>().Where(t => t.Name.Equals(name, StringComparison.OrdinalIgnoreCase)).AsImmutable();
 
         internal override IEnumerable<IFieldSymbol> GetFieldsToEmit() => GetMembers().OfType<FieldSymbol>();
 

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceRoutineSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceRoutineSymbol.cs
@@ -98,6 +98,8 @@ namespace Pchp.CodeAnalysis.Symbols
         /// </summary>
         internal abstract SourceFileSymbol ContainingFile { get; }
 
+        public override bool IsUnreachable => Flags.HasFlag(RoutineFlags.IsUnreachable);
+
         protected ImmutableArray<ParameterSymbol> _implicitParameters;
         private SourceParameterSymbol[] _srcParams;
 

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceSymbolCollection.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceSymbolCollection.cs
@@ -283,7 +283,7 @@ namespace Pchp.CodeAnalysis.Symbols
             NamedTypeSymbol first = null;
             List<NamedTypeSymbol> alternatives = null;
 
-            var types = _types.GetAll(name).SelectMany(t => t.AllVersions());   // get all types with {name} and their versions
+            var types = _types.GetAll(name).SelectMany(t => t.AllReachableVersions());   // get all types with {name} and their versions
             foreach (var t in types)
             {
                 if (first == null)
@@ -322,6 +322,6 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <summary>
         /// Gets all source types and their versions.
         /// </summary>
-        public IEnumerable<SourceTypeSymbol> GetTypes() => GetDeclaredTypes().SelectMany(t => t.AllVersions());
+        public IEnumerable<SourceTypeSymbol> GetTypes() => GetDeclaredTypes().SelectMany(t => t.AllReachableVersions());
     }
 }

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceSymbolCollection.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceSymbolCollection.cs
@@ -13,6 +13,7 @@ using Pchp.CodeAnalysis.Utilities;
 using Devsense.PHP.Syntax;
 using Devsense.PHP.Syntax.Ast;
 using static Pchp.CodeAnalysis.AstUtils;
+using Pchp.CodeAnalysis.FlowAnalysis;
 
 namespace Pchp.CodeAnalysis.Symbols
 {
@@ -242,17 +243,17 @@ namespace Pchp.CodeAnalysis.Symbols
         /// </summary>
         public MethodSymbol GetFunction(QualifiedName name)
         {
-            var fncs = _functions.GetAll(name).AsImmutable();
+            var fncs = _functions.GetAll(name).Where(f => !f.IsUnreachable).AsImmutable();
             if (fncs.Length == 1 && !fncs[0].IsConditional) return fncs[0];
             if (fncs.Length == 0) return new MissingMethodSymbol(name.Name.Value);
             return new AmbiguousMethodSymbol(fncs.AsImmutable<MethodSymbol>(), overloadable: false);
         }
 
-        public IEnumerable<MethodSymbol> GetFunctions(QualifiedName name) => _functions[name];
+        public IEnumerable<MethodSymbol> GetFunctions(QualifiedName name) => _functions[name].Where(f => !f.IsUnreachable);
 
         public IEnumerable<SourceFunctionSymbol> GetFunctions()
         {
-            return _functions.Symbols;
+            return _functions.Symbols.Where(f => !f.IsUnreachable);
         }
 
         public IEnumerable<SourceLambdaSymbol> GetLambdas()

--- a/src/Peachpie.CodeAnalysis/Symbols/Symbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Symbol.cs
@@ -300,6 +300,12 @@ namespace Pchp.CodeAnalysis
         }
 
         /// <summary>
+        /// Returns true if this symbol is declared in the source code, but this declaration is proven
+        /// to be unreachable in execution. Symbols marked this way will not by emitted.
+        /// </summary>
+        public virtual bool IsUnreachable => false;
+
+        /// <summary>
         /// Returns true if this symbol can be referenced by its name in code. Examples of symbols
         /// that cannot be referenced by name are:
         ///    constructors, destructors, operators, explicit interface implementations,

--- a/tests/classes/conditional_001.php
+++ b/tests/classes/conditional_001.php
@@ -11,6 +11,11 @@ else {
 	}
 }
 
+class Y extends X {
+	function bar() { parent::foo(); }
+}
+
 (new X)->foo();
+(new Y)->bar();
 
 echo "Done.";


### PR DESCRIPTION
After each possibly parallel transformation run, mark all functions and types with unreachable declarations. Those are then not considered in lookups and emit.