### PR TITLE
PDOStatement - Fix FETCH_COLUMN exception

### DIFF
--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -888,7 +888,7 @@ namespace Peachpie.Library.PDO
                         case PDO.PDO_FETCH.FETCH_NUM:
                             return PhpValue.Create(this.ReadArray(false, true));
                         case PDO.PDO_FETCH.FETCH_COLUMN:
-                            if (FetchColNo != -1)
+                            if (FetchColNo == -1)
                             {
                                 m_pdo.HandleError(new PDOException("The column number for FETCH_COLUMN mode is not set."));
                                 return PhpValue.False;


### PR DESCRIPTION
The code for fetching columns fails when you DO set a column index.

Example of code that fails: 
```php
$columnIndex = 0
$fullColumn = $this->pdoStatement->fetchAll(PDO::FETCH_COLUMN, $columnIndex);
```