### PR TITLE
Objects - is_subclass_of works properly with same parent class

### DIFF
--- a/src/Peachpie.Library/Objects.cs
+++ b/src/Peachpie.Library/Objects.cs
@@ -30,7 +30,7 @@ namespace Pchp.Library
             if (base_tinfo == null) return false;
 
             //
-            return base_tinfo.Type.IsAssignableFrom(tinfo.Type);
+            return base_tinfo.Type.IsAssignableFrom(tinfo.Type) && base_tinfo.Type != tinfo.Type;
         }
 
         /// <summary>


### PR DESCRIPTION
The bug is the is_subclass returns true when you pass the same class as the parent and the child. It should return false.