### PR TITLE
Restore values changed to aliases by iterator (OrderedDictionary.Enumerator.CurrentValueAliased)

### DIFF
--- a/src/Peachpie.Runtime/PhpAlias.cs
+++ b/src/Peachpie.Runtime/PhpAlias.cs
@@ -33,6 +33,15 @@ namespace Pchp.Core
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public int ReferenceCount { get; private set; }
 
+        internal bool IsAliasForIterator => _iteratorAliasCount > 0;
+
+        internal void IncIteratorAliasCount() => _iteratorAliasCount++;
+
+        internal int DecIteratorAliasCount() => --_iteratorAliasCount;
+
+        // how many times the underlying value was converted to an alias in OrderedDictionary.Enumerator.CurrentValueAliased
+        private int _iteratorAliasCount;
+
         #endregion
 
         #region Construction

--- a/tests/arrays/foreach_005.php
+++ b/tests/arrays/foreach_005.php
@@ -1,0 +1,20 @@
+<?php
+
+// Test if PhpArray iterator is not changing the values to references (issue #345)
+
+function test() {
+	$t = 3;
+	$a = array('v1' => 1, 'v2' => 2, 'v3' => &$t);
+	
+	foreach($a as &$v) {
+		$v = $v + 1;
+	}
+	
+	$b = $a;
+	$a['v1'] = 10; // $b shouldn't change
+	
+	print_r($a);
+	print_r($b);
+}
+
+test();


### PR DESCRIPTION
Fix for #345 