### PR TITLE
Reference the entry assembly when using eval. Fixes #422

### DIFF
--- a/src/Peachpie.Library.Scripting/PhpCompilationFactory.cs
+++ b/src/Peachpie.Library.Scripting/PhpCompilationFactory.cs
@@ -85,7 +85,12 @@ namespace Peachpie.Library.Scripting
             var list = types.Distinct().Select(ass => ass.GetTypeInfo().Assembly).ToList();
             var set = new HashSet<Assembly>(list);
 
-            list.Add(System.Reflection.Assembly.GetEntryAssembly());
+            // Add entry assembly if its loadable
+            var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
+
+            if (!entryAssembly.IsDynamic && entryAssembly.Location.Length != 0) {
+                list.Add(entryAssembly);
+            }
 
             for (int i = 0; i < list.Count; i++)
             {

--- a/src/Peachpie.Library.Scripting/PhpCompilationFactory.cs
+++ b/src/Peachpie.Library.Scripting/PhpCompilationFactory.cs
@@ -85,6 +85,8 @@ namespace Peachpie.Library.Scripting
             var list = types.Distinct().Select(ass => ass.GetTypeInfo().Assembly).ToList();
             var set = new HashSet<Assembly>(list);
 
+            list.Add(System.Reflection.Assembly.GetEntryAssembly());
+
             for (int i = 0; i < list.Count; i++)
             {
                 var assembly = list[i];

--- a/src/Peachpie.Library.Scripting/PhpCompilationFactory.cs
+++ b/src/Peachpie.Library.Scripting/PhpCompilationFactory.cs
@@ -85,12 +85,8 @@ namespace Peachpie.Library.Scripting
             var list = types.Distinct().Select(ass => ass.GetTypeInfo().Assembly).ToList();
             var set = new HashSet<Assembly>(list);
 
-            // Add entry assembly if its loadable
-            var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
-
-            if (!entryAssembly.IsDynamic && entryAssembly.Location.Length != 0) {
-                list.Add(entryAssembly);
-            }
+            // Add entry assembly
+            list.Add(System.Reflection.Assembly.GetEntryAssembly());
 
             for (int i = 0; i < list.Count; i++)
             {
@@ -98,10 +94,14 @@ namespace Peachpie.Library.Scripting
                 var refs = assembly.GetReferencedAssemblies();
                 foreach (var refname in refs)
                 {
-                    var refassembly = Assembly.Load(refname);
-                    if (refassembly != null && set.Add(refassembly))
-                    {
-                        list.Add(refassembly);
+                    try {
+                        var refassembly = Assembly.Load(refname);
+                        if (refassembly != null && set.Add(refassembly))
+                        {
+                            list.Add(refassembly);
+                        }
+                    } catch {
+                        // ignore issues related to loading the assembly
                     }
                 }
             }


### PR DESCRIPTION
Hopefully this is a better change then the previous PR in https://github.com/peachpiecompiler/peachpie/pull/423

When running eval the code doesn't reference assemblies linked by the entry assembly. This causes it to get issues when there is PHP code in another assembly. An example of this bug can be found here: https://github.com/calvinbaart/bug-peachpie-eval

Running assembly2 causes it to crash with the following error:

```
Unhandled Exception: System.InvalidOperationException: Type name 'TestClass' could not be resolved.
   at Pchp.Core.DefaultErrorHandler.Throw(PhpError error, String message)
   at Peachpie.Library.Scripting.Script.<>c__DisplayClass15_0.<CreateInvalid>b__0(Context ctx, PhpArray locals, Object this, RuntimeTypeHandle self)
   at Peachpie.Library.Scripting.Script.Evaluate(Context ctx, PhpArray locals, Object this, RuntimeTypeHandle self)
   at Pchp.Core.Operators.Eval(Context ctx, PhpArray locals, Object this, RuntimeTypeHandle self, String code, String currentpath, Int32 line, Int32 column)
   at <Root>.test_php.<Main>(Context <ctx>, PhpArray <locals>, Object this, RuntimeTypeHandle <self>) in /Users/calvinbaart/Development/peachpie-bug-sample/assembly2/test.php:line 7
   at <Script>.Main(String[] args)
```