### PR TITLE
Cache fix for Eval

### DIFF
--- a/src/Peachpie.Library.Scripting/Context.ScriptingProvider.cs
+++ b/src/Peachpie.Library.Scripting/Context.ScriptingProvider.cs
@@ -68,7 +68,7 @@ namespace Peachpie.Library.Scripting
             {
                 // candidate requires that all its dependencies were loaded into context
                 // TODO: resolve the compiled code dependencies - referenced types and declared functions - instead of "DependingSubmissions"
-                if (c.DependingSubmissions.All(context.Submissions.Contains))
+                if (c.DependingSubmissions?.All(context.Submissions.Contains) == true)
                 {
                     return c;
                 }


### PR DESCRIPTION
Noticed that when running alot of Evals the Cache check fails with this exception:
```
PHPUnit\Framework\WrappedException: System.ArgumentNullException: Value cannot be null.
Parameter name: source
   at System.Linq.Enumerable.All[TSource](IEnumerable`1 source, Func`2 predicate)
   at Peachpie.Library.Scripting.ScriptingProvider.CacheLookupNoLock(List`1 candidates, ScriptOptions options, String code, ScriptingContext context)
   at Peachpie.Library.Scripting.ScriptingProvider.TryGetOrCreateScript(String code, ScriptOptions options, ScriptingContext context)
   at Peachpie.Library.Scripting.ScriptingProvider.Pchp.Core.Context.IScriptingProvider.CreateScript(ScriptOptions options, String code)
   at Pchp.Core.Operators.Eval(Context ctx, PhpArray locals, Object this, RuntimeTypeHandle self, String code, String currentpath, Int32 line, Int32 column)
   at Mockery.Loader.EvalLoader.load(MockDefinition definition) in /home/travis/build/calvinbaart/laravel-peachpie-sample/Laravel.Tests/vendor/mockery/mockery/library/Mockery/Loader/EvalLoader.php:line 34
   at CallSite.Target(Closure , CallSite , PhpValue , Context , PhpValue& )
   at Mockery.Container.mock(PhpValue[] args) in /home/travis/build/calvinbaart/laravel-peachpie-sample/Laravel.Tests/vendor/mockery/mockery/library/Mockery/Container.php:line 230
   at <>.mock(Container , PhpValue[] )
   at Mockery.mock(Context <ctx>, PhpValue[] args)
   at Illuminate.Tests.Auth.AuthEloquentUserProviderTest.getProviderMock()
   at Illuminate.Tests.Auth.AuthEloquentUserProviderTest.testRetrieveTokenWithBadIdentifierReturnsNull()
   at System.Dynamic.UpdateDelegates.UpdateAndExecute4[T0,T1,T2,T3,TRet](CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
   at CallSite.Target(Closure , CallSite , TestCase , NameParam`1 , Context , UnpackingParam`1 )
   at PHPUnit.Framework.TestCase.runTest()
```

This code adds a basic null-check to make sure the code continues.