### PR TITLE
Fix decrementing of next free key in array_pop

### DIFF
--- a/src/Peachpie.Runtime/OrderedDictionary.cs
+++ b/src/Peachpie.Runtime/OrderedDictionary.cs
@@ -199,7 +199,7 @@ namespace Pchp.Core
         int _dataDeleted;       // number of deleted elements within (0.._dataUsed] => Count = _dataUsed - _dataDeleted
         uint _size;             // physical size of the table (power of 2, minimum 8)
         //int nInternalPointer;   // intrinsic enumerator pointer
-        internal int _nextFreeKey;       // the next integer key that will be used when inserting an element. It is one larger than the largest integer key that was ever used in this hashtable.
+        int _nextFreeKey;       // the next integer key that will be used when inserting an element. It is one larger than the largest integer key that was ever used in this hashtable.
 
         /// <summary>
         /// Additional references sharing this object.
@@ -565,7 +565,7 @@ namespace Pchp.Core
 
         #endregion
 
-        #region Methods: Add*, Get*, Remove, Clear
+        #region Methods: Add*, Get*, Remove, TryRemoveLast, Clear
 
         /// <summary>
         /// Gets index of the item within private <see cref="_data"/> array.
@@ -880,6 +880,35 @@ namespace Pchp.Core
 
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Remove the last item in the array and return it, if it exists. If the next free index was its index,
+        /// decrement it (semantics of <c>array_pop</c>).
+        /// </summary>
+        /// <param name="value">The removed item with its key.</param>
+        /// <returns><c>true</c> if the array was non-empty and the item was removed, otherwise <c>false</c></returns>
+        public bool TryRemoveLast(out KeyValuePair<IntStringKey, TValue> value)
+        {
+            var enumerator = GetEnumerator();
+            if (enumerator.MoveLast())
+            {
+                value = enumerator.Current;
+                enumerator.DeleteCurrent();
+
+                // array_pop decrements the next free index if it removed the last record before it
+                if (value.Key.IsInteger && value.Key.Integer == _nextFreeKey - 1)
+                {
+                    _nextFreeKey--;
+                }
+
+                return true;
+            }
+
+            //
+
+            value = default;
+            return false;
         }
 
         /// <summary>
@@ -1872,22 +1901,6 @@ namespace Pchp.Core
         {
             var enumerator = array.GetEnumerator();
             if (enumerator.MoveNext())
-            {
-                value = enumerator.Current;
-                enumerator.DeleteCurrent();
-                return true;
-            }
-
-            //
-
-            value = default;
-            return false;
-        }
-
-        public static bool TryRemoveLast(this OrderedDictionary/*<TValue>*/ array, out KeyValuePair<IntStringKey, TValue> value)
-        {
-            var enumerator = array.GetEnumerator();
-            if (enumerator.MoveLast())
             {
                 value = enumerator.Current;
                 enumerator.DeleteCurrent();

--- a/src/Peachpie.Runtime/OrderedDictionary.cs
+++ b/src/Peachpie.Runtime/OrderedDictionary.cs
@@ -199,7 +199,7 @@ namespace Pchp.Core
         int _dataDeleted;       // number of deleted elements within (0.._dataUsed] => Count = _dataUsed - _dataDeleted
         uint _size;             // physical size of the table (power of 2, minimum 8)
         //int nInternalPointer;   // intrinsic enumerator pointer
-        int _nextFreeKey;       // the next integer key that will be used when inserting an element. It is one larger than the largest integer key that was ever used in this hashtable.
+        internal int _nextFreeKey;       // the next integer key that will be used when inserting an element. It is one larger than the largest integer key that was ever used in this hashtable.
 
         /// <summary>
         /// Additional references sharing this object.

--- a/src/Peachpie.Runtime/PhpHashtable.cs
+++ b/src/Peachpie.Runtime/PhpHashtable.cs
@@ -721,12 +721,6 @@ namespace Pchp.Core
 
             if (table.TryRemoveLast(out var pair))
             {
-                // array_pop decrements the next free index if it removed the last record before it
-                if (pair.Key.IsInteger && pair.Key.Integer == table._nextFreeKey - 1)
-                {
-                    table._nextFreeKey--;
-                }
-
                 return pair;
             }
             else

--- a/src/Peachpie.Runtime/PhpHashtable.cs
+++ b/src/Peachpie.Runtime/PhpHashtable.cs
@@ -721,10 +721,10 @@ namespace Pchp.Core
 
             if (table.TryRemoveLast(out var pair))
             {
-                // array_pop decreases next free index if appropriate:
-                //if (pair.Key.IsInteger && pair.Key.Integer >= table.nNextFreeIndex)
+                // array_pop decrements the next free index if it removed the last record before it
+                if (pair.Key.IsInteger && pair.Key.Integer == table._nextFreeKey - 1)
                 {
-                    // TODO: ??? decrease the index ?
+                    table._nextFreeKey--;
                 }
 
                 return pair;

--- a/tests/arrays/array_pop_001.php
+++ b/tests/arrays/array_pop_001.php
@@ -1,0 +1,15 @@
+<?php
+
+
+function test($a) {
+  array_pop($a);
+  $a[] = "last";
+  print_r($a);
+}
+
+test(["foo"]);
+test(["foo", "bar"]);
+test([3 => "foo", 8 => "bar"]);
+test(["foo" => "foo", "bar" => "bar"]);
+test(["foo" => "foo", 4 => "bar", 8 => "baz"]);
+test(["foo" => "foo", 8 => "baz", 4 => "bar"]);


### PR DESCRIPTION
Implements the decrementation of `_nextFreeKey` after `array_pop` (see https://github.com/php/php-src/blob/62751b0d453ac51c559ea31d360a290081eb0c1d/ext/standard/array.c#L3221). I know that making the field `internal` is not an ideal way to do this, but adding a helper method to `OrderedDictionary` specially for `array_pop` seemed too cumbersome as well. So I'd better leave the encapsulation to you :-) Or just tell me where to put it and I'll do it. Thanks.