### PR TITLE
Update ImageSharp to latest beta

### DIFF
--- a/src/Peachpie.Library.Graphics/Exif.cs
+++ b/src/Peachpie.Library.Graphics/Exif.cs
@@ -5,7 +5,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.Formats.Jpeg;
-using SixLabors.ImageSharp.MetaData.Profiles.Exif;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace Peachpie.Library.Graphics
@@ -92,7 +92,7 @@ namespace Peachpie.Library.Graphics
             {
                 try
                 {
-                    image = Image.Load(ms);
+                    image = Image.Load<Rgba32>(ms);
                 }
                 catch
                 {
@@ -104,9 +104,9 @@ namespace Peachpie.Library.Graphics
 
                 // TODO: image.MetaData.Properties, image.MetaData.IccProfile, image.MetaData.***Resolution
 
-                if (image.MetaData.ExifProfile != null)
+                if (image.Metadata.ExifProfile != null)
                 {
-                    foreach (var item in image.MetaData.ExifProfile.Values)
+                    foreach (var item in image.Metadata.ExifProfile.Values)
                     {
                         array.Add(item.Tag.ToString(), ExifValueToPhpValue(item.Value));
                     }
@@ -330,7 +330,7 @@ namespace Peachpie.Library.Graphics
                     using (var image = Image.Load(ms, out format))
                     {
                         // return byte[] ~ image.MetaData.ExifProfile{ this.data, this.thumbnailOffset, this.thumbnailLength }
-                        thumbnail = image.MetaData.ExifProfile.CreateThumbnail<Rgba32>();
+                        thumbnail = image.Metadata.ExifProfile.CreateThumbnail<Rgba32>();
                     }
                 }
                 catch

--- a/src/Peachpie.Library.Graphics/Exif.cs
+++ b/src/Peachpie.Library.Graphics/Exif.cs
@@ -86,13 +86,13 @@ namespace Peachpie.Library.Graphics
             //array.Add("FileDateTime", (int)File.GetCreationTime(filename).ToOADate());
             array.Add("FileSize", (int)bytes.Length);
 
-            Image<Rgba32> image;
+            IImageInfo image;
 
             using (var ms = new MemoryStream(bytes))
             {
                 try
                 {
-                    image = Image.Load<Rgba32>(ms);
+                    image = Image.Identify(ms);
                 }
                 catch
                 {
@@ -111,8 +111,6 @@ namespace Peachpie.Library.Graphics
                         array.Add(item.Tag.ToString(), ExifValueToPhpValue(item.Value));
                     }
                 }
-
-                image.Dispose();
             }
 
             return array;
@@ -327,6 +325,7 @@ namespace Peachpie.Library.Graphics
             {
                 try
                 {
+                    // TODO: Image.Identify needs a new overload that returns the format.
                     using (var image = Image.Load(ms, out format))
                     {
                         // return byte[] ~ image.MetaData.ExifProfile{ this.data, this.thumbnailOffset, this.thumbnailLength }

--- a/src/Peachpie.Library.Graphics/FloodFillProcessor.cs
+++ b/src/Peachpie.Library.Graphics/FloodFillProcessor.cs
@@ -1,23 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Text;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
+﻿using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing.Processors;
 using SixLabors.Primitives;
 
 namespace Peachpie.Library.Graphics
 {
-    internal class FloodFillProcessor<TPixel> : IImageProcessor<TPixel>
-                where TPixel : struct, IPixel<TPixel>
+    internal class FloodFillProcessor : IImageProcessor
     {
-        private readonly Point _startPoint;
-        private readonly TPixel _fillColor;
-        private readonly bool _toBorder;
-        private readonly TPixel _borderColor;
-
         /// <summary>
         /// Creates a processor to perform a flood fill of an image. Either until a border with specified color is reached, or the region with original color.
         /// </summary>
@@ -25,154 +14,24 @@ namespace Peachpie.Library.Graphics
         /// <param name="fillColor">Color to be filled with.</param>
         /// <param name="toBorder">False - color the connected region of same color, True - color until border is reached.</param>
         /// <param name="borderColor">Color of the region border, used if toBorder = True.</param>
-        public FloodFillProcessor(Point startPoint, TPixel fillColor, bool toBorder, TPixel borderColor)
+        public FloodFillProcessor(Point startPoint, Color fillColor, bool toBorder, Color borderColor)
         {
-            _startPoint = startPoint;
-            _fillColor = fillColor;
-            _toBorder = toBorder;
-            _borderColor = borderColor;
+            StartPoint = startPoint;
+            FillColor = fillColor;
+            ToBorder = toBorder;
+            BorderColor = borderColor;
         }
 
-        public void Apply(Image<TPixel> image, Rectangle sourceRectangle)
-        {
-            var floodFrom = image[_startPoint.X, _startPoint.Y];
+        public Point StartPoint { get; }
 
-            // The same color cannot be filled with itself
-            if (floodFrom.Equals(_fillColor))
-                return;
+        public Color FillColor { get; }
 
-            var pixelSpan = image.GetPixelSpan();
-            int rowLength = image.Width;
+        public bool ToBorder { get; }
 
-            var segmentQueue = new Queue<(Point point, int rightEdge)>();
-            segmentQueue.Enqueue((_startPoint, _startPoint.X));
+        public Color BorderColor { get; }
 
-            while (segmentQueue.Count > 0)
-            {
-                var (currentPoint, rightEdge) = segmentQueue.Dequeue();
-                var currentY = currentPoint.Y;
-                var currentX = currentPoint.X;
-
-                int leftEdge;
-                leftEdge = currentX;
-
-                // Filling until reaching a border of specified color
-                if (_toBorder)
-                {
-                    // Get the row segment to be colored
-                    while (rightEdge + 1 < image.Width)
-                    {
-                        var edgeColor = GetPixel(pixelSpan, rowLength, rightEdge + 1, currentY);
-                        if (edgeColor.Equals(_borderColor) || edgeColor.Equals(_fillColor))
-                            break;
-
-                        rightEdge++;
-                    }
-                    while (leftEdge - 1 < image.Width)
-                    {
-                        var edgeColor = GetPixel(pixelSpan, rowLength, leftEdge - 1, currentY);
-                        if (edgeColor.Equals(_borderColor) || edgeColor.Equals(_fillColor))
-                            break;
-
-                        leftEdge--;
-                    }
-
-                    // Actually color the row
-                    SetPixelRow(pixelSpan, rowLength, leftEdge, rightEdge, currentY, _fillColor);
-
-                    // Add the segments to be filled above and below to the queue
-                    if (currentY > 0)
-                        AddFillingSegmentsToQueueWithBorder(floodFrom, pixelSpan, segmentQueue, rowLength, leftEdge, rightEdge, currentY - 1);
-                    if (currentY + 1 < image.Height)
-                        AddFillingSegmentsToQueueWithBorder(floodFrom, pixelSpan, segmentQueue, rowLength, leftEdge, rightEdge, currentY + 1);
-                }
-                else
-                // Filling whole region of same color
-                {
-                    // Get the row segment to be colored
-                    while (rightEdge + 1 < image.Width && GetPixel(pixelSpan, rowLength, rightEdge + 1, currentY).Equals(floodFrom))
-                        rightEdge++;
-                    while (leftEdge > 0 && GetPixel(pixelSpan, rowLength, leftEdge - 1, currentY).Equals(floodFrom))
-                        leftEdge--;
-
-                    // Actually color the row
-                    SetPixelRow(pixelSpan, rowLength, leftEdge, rightEdge, currentY, _fillColor);
-
-                    // Add the segments to be filled above and below to the queue
-                    if (currentY > 0)
-                        AddFillingSegmentsToQueue(floodFrom, pixelSpan, segmentQueue, rowLength, leftEdge, rightEdge, currentY - 1);
-                    if (currentY + 1 < image.Height)
-                        AddFillingSegmentsToQueue(floodFrom, pixelSpan, segmentQueue, rowLength, leftEdge, rightEdge, currentY + 1);
-                }
-            }
-        }
-
-        private static void AddFillingSegmentsToQueue(TPixel floodFrom, Span<TPixel> pixelSpan, Queue<(Point, int)> segmentQueue, int rowLength, int xStart, int xEnd, int y)
-        {
-            int? markStart = null;
-
-            int rowStart = y * rowLength;
-            for (int x = xStart; x <= xEnd; x++)
-            {
-                var color = pixelSpan[rowStart + x];
-                if (markStart != null)
-                {
-                    if (!color.Equals(floodFrom))
-                    {
-                        segmentQueue.Enqueue((new Point(markStart.Value, y), x - 1));
-                        markStart = null;
-                    }
-                }
-                else
-                {
-                    if (color.Equals(floodFrom))
-                    {
-                        markStart = x;
-                    }
-                }
-            }
-
-            if (markStart != null)
-            {
-                segmentQueue.Enqueue((new Point(markStart.Value, y), xEnd));
-            }
-        }
-
-        private void AddFillingSegmentsToQueueWithBorder(TPixel floodFrom, Span<TPixel> pixelSpan, Queue<(Point, int)> segmentQueue, int rowLength, int xStart, int xEnd, int y)
-        {
-            int? markStart = null;
-
-            int rowStart = y * rowLength;
-            for (int x = xStart; x <= xEnd; x++)
-            {
-                var color = pixelSpan[rowStart + x];
-                if (markStart != null)
-                {
-                    if (color.Equals(_borderColor) || color.Equals(_fillColor))
-                    {
-                        segmentQueue.Enqueue((new Point(markStart.Value, y), x - 1));
-                        markStart = null;
-                    }
-                }
-                else
-                {
-                    if (!color.Equals(_borderColor) && !color.Equals(_fillColor))
-                    {
-                        markStart = x;
-                    }
-                }
-            }
-
-            if (markStart != null)
-            {
-                segmentQueue.Enqueue((new Point(markStart.Value, y), xEnd));
-            }
-        }
-
-        private static TPixel GetPixel(Span<TPixel> span, int rowLength, int x, int y) => span[y * rowLength + x];
-
-        private static void SetPixel(Span<TPixel> span, int rowLength, int x, int y, TPixel color) => span[y * rowLength + x] = color;
-
-        private static void SetPixelRow(Span<TPixel> span, int rowLength, int xFrom, int xTo, int y, TPixel color) => span.Slice(y * rowLength + xFrom, xTo - xFrom + 1).Fill(color);
+        public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Image<TPixel> source, Rectangle sourceRectangle)
+            where TPixel : struct, IPixel<TPixel>
+            => new FloodFillProcessor<TPixel>(this, source, sourceRectangle);
     }
 }

--- a/src/Peachpie.Library.Graphics/FloodFillProcessor{TPixel}.cs
+++ b/src/Peachpie.Library.Graphics/FloodFillProcessor{TPixel}.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.Primitives;
+
+namespace Peachpie.Library.Graphics
+{
+    internal class FloodFillProcessor<TPixel> : ImageProcessor<TPixel>
+        where TPixel : struct, IPixel<TPixel>
+    {
+        private readonly Point _startPoint;
+        private readonly TPixel _fillColor;
+        private readonly bool _toBorder;
+        private readonly TPixel _borderColor;
+
+        public FloodFillProcessor(FloodFillProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
+            : base(source, sourceRectangle)
+        {
+            _startPoint = definition.StartPoint;
+            _fillColor = definition.FillColor.ToPixel<TPixel>();
+            _toBorder = definition.ToBorder;
+            _borderColor = definition.BorderColor.ToPixel<TPixel>();
+        }
+
+        protected override void OnFrameApply(ImageFrame<TPixel> source)
+        {
+            var floodFrom = source[_startPoint.X, _startPoint.Y];
+
+            // The same color cannot be filled with itself
+            if (floodFrom.Equals(_fillColor))
+                return;
+
+            var pixelSpan = source.GetPixelSpan();
+            int rowLength = source.Width;
+
+            var segmentQueue = new Queue<(Point point, int rightEdge)>();
+            segmentQueue.Enqueue((_startPoint, _startPoint.X));
+
+            while (segmentQueue.Count > 0)
+            {
+                var (currentPoint, rightEdge) = segmentQueue.Dequeue();
+                var currentY = currentPoint.Y;
+                var currentX = currentPoint.X;
+
+                int leftEdge;
+                leftEdge = currentX;
+
+                // Filling until reaching a border of specified color
+                if (_toBorder)
+                {
+                    // Get the row segment to be colored
+                    while (rightEdge + 1 < source.Width)
+                    {
+                        var edgeColor = GetPixel(pixelSpan, rowLength, rightEdge + 1, currentY);
+                        if (edgeColor.Equals(_borderColor) || edgeColor.Equals(_fillColor))
+                            break;
+
+                        rightEdge++;
+                    }
+                    while (leftEdge - 1 < source.Width)
+                    {
+                        var edgeColor = GetPixel(pixelSpan, rowLength, leftEdge - 1, currentY);
+                        if (edgeColor.Equals(_borderColor) || edgeColor.Equals(_fillColor))
+                            break;
+
+                        leftEdge--;
+                    }
+
+                    // Actually color the row
+                    SetPixelRow(pixelSpan, rowLength, leftEdge, rightEdge, currentY, _fillColor);
+
+                    // Add the segments to be filled above and below to the queue
+                    if (currentY > 0)
+                        AddFillingSegmentsToQueueWithBorder(floodFrom, pixelSpan, segmentQueue, rowLength, leftEdge, rightEdge, currentY - 1);
+                    if (currentY + 1 < source.Height)
+                        AddFillingSegmentsToQueueWithBorder(floodFrom, pixelSpan, segmentQueue, rowLength, leftEdge, rightEdge, currentY + 1);
+                }
+                else
+                // Filling whole region of same color
+                {
+                    // Get the row segment to be colored
+                    while (rightEdge + 1 < source.Width && GetPixel(pixelSpan, rowLength, rightEdge + 1, currentY).Equals(floodFrom))
+                        rightEdge++;
+                    while (leftEdge > 0 && GetPixel(pixelSpan, rowLength, leftEdge - 1, currentY).Equals(floodFrom))
+                        leftEdge--;
+
+                    // Actually color the row
+                    SetPixelRow(pixelSpan, rowLength, leftEdge, rightEdge, currentY, _fillColor);
+
+                    // Add the segments to be filled above and below to the queue
+                    if (currentY > 0)
+                        AddFillingSegmentsToQueue(floodFrom, pixelSpan, segmentQueue, rowLength, leftEdge, rightEdge, currentY - 1);
+                    if (currentY + 1 < source.Height)
+                        AddFillingSegmentsToQueue(floodFrom, pixelSpan, segmentQueue, rowLength, leftEdge, rightEdge, currentY + 1);
+                }
+            }
+        }
+
+        private static void AddFillingSegmentsToQueue(TPixel floodFrom, Span<TPixel> pixelSpan, Queue<(Point, int)> segmentQueue, int rowLength, int xStart, int xEnd, int y)
+        {
+            int? markStart = null;
+
+            int rowStart = y * rowLength;
+            for (int x = xStart; x <= xEnd; x++)
+            {
+                var color = pixelSpan[rowStart + x];
+                if (markStart != null)
+                {
+                    if (!color.Equals(floodFrom))
+                    {
+                        segmentQueue.Enqueue((new Point(markStart.Value, y), x - 1));
+                        markStart = null;
+                    }
+                }
+                else
+                {
+                    if (color.Equals(floodFrom))
+                    {
+                        markStart = x;
+                    }
+                }
+            }
+
+            if (markStart != null)
+            {
+                segmentQueue.Enqueue((new Point(markStart.Value, y), xEnd));
+            }
+        }
+
+        private void AddFillingSegmentsToQueueWithBorder(TPixel floodFrom, Span<TPixel> pixelSpan, Queue<(Point, int)> segmentQueue, int rowLength, int xStart, int xEnd, int y)
+        {
+            int? markStart = null;
+
+            int rowStart = y * rowLength;
+            for (int x = xStart; x <= xEnd; x++)
+            {
+                var color = pixelSpan[rowStart + x];
+                if (markStart != null)
+                {
+                    if (color.Equals(_borderColor) || color.Equals(_fillColor))
+                    {
+                        segmentQueue.Enqueue((new Point(markStart.Value, y), x - 1));
+                        markStart = null;
+                    }
+                }
+                else
+                {
+                    if (!color.Equals(_borderColor) && !color.Equals(_fillColor))
+                    {
+                        markStart = x;
+                    }
+                }
+            }
+
+            if (markStart != null)
+            {
+                segmentQueue.Enqueue((new Point(markStart.Value, y), xEnd));
+            }
+        }
+
+        private static TPixel GetPixel(Span<TPixel> span, int rowLength, int x, int y) => span[y * rowLength + x];
+
+        private static void SetPixel(Span<TPixel> span, int rowLength, int x, int y, TPixel color) => span[y * rowLength + x] = color;
+
+        private static void SetPixelRow(Span<TPixel> span, int rowLength, int xFrom, int xTo, int y, TPixel color) => span.Slice(y * rowLength + xFrom, xTo - xFrom + 1).Fill(color);
+    }
+}

--- a/src/Peachpie.Library.Graphics/ImageProcessor{TPixel}.cs
+++ b/src/Peachpie.Library.Graphics/ImageProcessor{TPixel}.cs
@@ -11,8 +11,8 @@ namespace Peachpie.Library.Graphics
     /// The base class for all pixel specific image processors.
     /// </summary>
     /// <remarks>
-    /// This is a copy of the base class fom the ImageSharp project adjusted to only process
-    /// and preserve the first frame in multi-frame images.
+    /// This is a copy of the base class fom the ImageSharp project and can be deleted 
+    /// once the ImageSharp RC1 is shipped.
     /// </remarks>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
     internal abstract class ImageProcessor<TPixel> : IImageProcessor<TPixel>
@@ -50,15 +50,6 @@ namespace Peachpie.Library.Graphics
         {
             try
             {
-                // PHP will only preserve the first frame of a manipulated image.
-                if (Source.Frames.Count > 0)
-                {
-                    for (int i = 1; i < Source.Frames.Count; i++)
-                    {
-                        Source.Frames.RemoveFrame(i);
-                    }
-                }
-
                 BeforeImageApply();
 
                 foreach (ImageFrame<TPixel> sourceFrame in Source.Frames)

--- a/src/Peachpie.Library.Graphics/ImageProcessor{TPixel}.cs
+++ b/src/Peachpie.Library.Graphics/ImageProcessor{TPixel}.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing.Processors;
+using SixLabors.Primitives;
+
+namespace Peachpie.Library.Graphics
+{
+    /// <summary>
+    /// The base class for all pixel specific image processors.
+    /// </summary>
+    /// <remarks>
+    /// This is a copy of the base class fom the ImageSharp project adjusted to only process
+    /// and preserve the first frame in multi-frame images.
+    /// </remarks>
+    /// <typeparam name="TPixel">The pixel format.</typeparam>
+    internal abstract class ImageProcessor<TPixel> : IImageProcessor<TPixel>
+        where TPixel : struct, IPixel<TPixel>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageProcessor{TPixel}"/> class.
+        /// </summary>
+        /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
+        /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
+        protected ImageProcessor(Image<TPixel> source, Rectangle sourceRectangle)
+        {
+            Source = source;
+            SourceRectangle = sourceRectangle;
+            Configuration = Source.GetConfiguration();
+        }
+
+        /// <summary>
+        /// Gets The source <see cref="Image{TPixel}"/> for the current processor instance.
+        /// </summary>
+        protected Image<TPixel> Source { get; }
+
+        /// <summary>
+        /// Gets The source area to process for the current processor instance.
+        /// </summary>
+        protected Rectangle SourceRectangle { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Configuration"/> instance to use when performing operations.
+        /// </summary>
+        protected Configuration Configuration { get; }
+
+        /// <inheritdoc/>
+        void IImageProcessor<TPixel>.Apply()
+        {
+            try
+            {
+                // PHP will only preserve the first frame of a manipulated image.
+                if (Source.Frames.Count > 0)
+                {
+                    for (int i = 1; i < Source.Frames.Count; i++)
+                    {
+                        Source.Frames.RemoveFrame(i);
+                    }
+                }
+
+                BeforeImageApply();
+
+                foreach (ImageFrame<TPixel> sourceFrame in Source.Frames)
+                {
+                    Apply(sourceFrame);
+                }
+
+                AfterImageApply();
+            }
+#if DEBUG
+            catch (Exception)
+            {
+                throw;
+#else
+            catch (Exception ex)
+            {
+                throw new ImageProcessingException($"An error occurred when processing the image using {this.GetType().Name}. See the inner exception for more detail.", ex);
+#endif
+            }
+        }
+
+        /// <summary>
+        /// Applies the processor to a single image frame.
+        /// </summary>
+        /// <param name="source">the source image.</param>
+        public void Apply(ImageFrame<TPixel> source)
+        {
+            try
+            {
+                BeforeFrameApply(source);
+                OnFrameApply(source);
+                AfterFrameApply(source);
+            }
+#if DEBUG
+            catch (Exception)
+            {
+                throw;
+#else
+            catch (Exception ex)
+            {
+                throw new ImageProcessingException($"An error occurred when processing the image using {this.GetType().Name}. See the inner exception for more detail.", ex);
+#endif
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// This method is called before the process is applied to prepare the processor.
+        /// </summary>
+        protected virtual void BeforeImageApply()
+        {
+        }
+
+        /// <summary>
+        /// This method is called before the process is applied to prepare the processor.
+        /// </summary>
+        /// <param name="source">The source image. Cannot be null.</param>
+        protected virtual void BeforeFrameApply(ImageFrame<TPixel> source)
+        {
+        }
+
+        /// <summary>
+        /// Applies the process to the specified portion of the specified <see cref="ImageFrame{TPixel}" /> at the specified location
+        /// and with the specified size.
+        /// </summary>
+        /// <param name="source">The source image. Cannot be null.</param>
+        protected abstract void OnFrameApply(ImageFrame<TPixel> source);
+
+        /// <summary>
+        /// This method is called after the process is applied to prepare the processor.
+        /// </summary>
+        /// <param name="source">The source image. Cannot be null.</param>
+        protected virtual void AfterFrameApply(ImageFrame<TPixel> source)
+        {
+        }
+
+        /// <summary>
+        /// This method is called after the process is applied to prepare the processor.
+        /// </summary>
+        protected virtual void AfterImageApply()
+        {
+        }
+
+        /// <summary>
+        /// Disposes the object and frees resources for the Garbage Collector.
+        /// </summary>
+        /// <param name="disposing">Whether to dispose managed and unmanaged objects.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/src/Peachpie.Library.Graphics/Peachpie.Library.Graphics.csproj
+++ b/src/Peachpie.Library.Graphics/Peachpie.Library.Graphics.csproj
@@ -11,9 +11,9 @@
     <Description>Peachpie PHP language library functions for image processing.</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0006" />
-    <PackageReference Include="SixLabors.Shapes.Text" Version="1.0.0-beta0008" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0007" />
+    <PackageReference Include="SixLabors.Shapes.Text" Version="1.0.0-beta0009" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Peachpie.Library.Graphics/PhpGd2.cs
+++ b/src/Peachpie.Library.Graphics/PhpGd2.cs
@@ -426,7 +426,7 @@ namespace Peachpie.Library.Graphics
 
             try
             {
-                return new PhpGdImageResource(Image.Load(image, out var format), format);
+                return new PhpGdImageResource(Image.Load<Rgba32>(image, out var format), format);
             }
             catch
             {
@@ -535,7 +535,7 @@ namespace Peachpie.Library.Graphics
             {
                 if (stream != null)
                 {
-                    try { img = Image.Load(configuration, stream, out format); }
+                    try { img = Image.Load<Rgba32>(configuration, stream, out format); }
                     catch { }
                 }
             }
@@ -1009,7 +1009,7 @@ namespace Peachpie.Library.Graphics
                 return false;
             }
 
-            img.tiled = new ImageBrush<Rgba32>(imgTile.Image);
+            img.tiled = new ImageBrush(imgTile.Image);
 
             return false;
         }
@@ -1444,7 +1444,7 @@ namespace Peachpie.Library.Graphics
             }
             else
             {
-                var brush = new SolidBrush<Rgba32>(GetAlphaColor(img, col));
+                var brush = new SolidBrush(GetAlphaColor(img, col));
                 img.Image.Mutate(o => o.Fill(brush, ellipse));
             }
 
@@ -1545,7 +1545,7 @@ namespace Peachpie.Library.Graphics
             var font = CreateFontById(fontInd);
             var color = FromRGBA(col);
 
-            img.Image.Mutate<Rgba32>(context => context.DrawText<Rgba32>(text, font, color, new PointF(x, y)));
+            img.Image.Mutate<Rgba32>(context => context.DrawText(text, font, color, new PointF(x, y)));
 
             return true;
         }
@@ -1625,7 +1625,7 @@ namespace Peachpie.Library.Graphics
             if (x < 0 || y < 0) return true;
             if (x > img.Image.Width || y > img.Image.Height) return true;
 
-            img.Image.Mutate(o => o.ApplyProcessor(new FloodFillProcessor<Rgba32>(new Point(x, y), FromRGBA(col), false, Rgba32.Red)));
+            img.Image.Mutate(o => o.ApplyProcessor(new FloodFillProcessor(new Point(x, y), FromRGBA(col), false, Color.Red)));
 
             return true;
         }
@@ -1652,7 +1652,7 @@ namespace Peachpie.Library.Graphics
             // Path Builder object to be used in all the branches
             PathBuilder pathBuilder = new PathBuilder();
             var color = FromRGBA(col);
-            var pen = new Pen<Rgba32>(color, 1);
+            var pen = new Pen(color, 1);
 
             // edge points, used for both pie and chord
             PointF startingPoint = new PointF(cx + (int)(Math.Cos(s * Math.PI / 180) * (w / 2.0)), cy + (int)(Math.Sin(s * Math.PI / 180) * (h / 2.0)));
@@ -1681,7 +1681,7 @@ namespace Peachpie.Library.Graphics
                     // Draw the prepared lines or fill the pie
                     if (style == ((int)FilledArcStyles.PIE | (int)FilledArcStyles.NOFILL))
                     {
-                        context.Draw<Rgba32>(pen, pathBuilder.Build());
+                        context.Draw(pen, pathBuilder.Build());
                     }
                     else
                     {
@@ -1691,12 +1691,12 @@ namespace Peachpie.Library.Graphics
 
                         if (style == ((int)FilledArcStyles.PIE | (int)FilledArcStyles.NOFILL | (int)FilledArcStyles.EDGED))
                         {
-                            context.Draw<Rgba32>(pen, pathBuilder.Build());
+                            context.Draw(pen, pathBuilder.Build());
                         }
                         else
                         {
                             //Last not-excluded option for PIE, a simple filled PIE
-                            context.Fill<Rgba32>(color, pathBuilder.Build());
+                            context.Fill(color, pathBuilder.Build());
                         }
                     }
                 }
@@ -1707,7 +1707,7 @@ namespace Peachpie.Library.Graphics
 
                     if (style == ((int)FilledArcStyles.CHORD | (int)FilledArcStyles.NOFILL))
                     {
-                        context.Draw<Rgba32>(pen, pathBuilder.Build());
+                        context.Draw(pen, pathBuilder.Build());
                     }
                     else
                     {
@@ -1717,12 +1717,12 @@ namespace Peachpie.Library.Graphics
 
                         if (style == ((int)FilledArcStyles.CHORD | (int)FilledArcStyles.NOFILL | (int)FilledArcStyles.EDGED))
                         {
-                            context.Draw<Rgba32>(pen, pathBuilder.Build());
+                            context.Draw(pen, pathBuilder.Build());
                         }
                         else
                         {
                             // Last remaining option is to fill the chord arc
-                            context.Fill<Rgba32>(color, pathBuilder.Build());
+                            context.Fill(color, pathBuilder.Build());
                         }
                     }
                 }
@@ -1906,7 +1906,7 @@ namespace Peachpie.Library.Graphics
 
             if (filled)
             {
-                IBrush<Rgba32> brush;
+                IBrush brush;
 
                 switch (col)
                 {
@@ -1920,7 +1920,7 @@ namespace Peachpie.Library.Graphics
                         brush = img.brushed;
                         break;
                     default:
-                        brush = new SolidBrush<Rgba32>(FromRGBA(col));
+                        brush = new SolidBrush(FromRGBA(col));
                         break;
                 }
 
@@ -1928,7 +1928,7 @@ namespace Peachpie.Library.Graphics
             }
             else
             {
-                img.Image.Mutate(o => o.DrawPolygon(new Pen<Rgba32>(FromRGBA(col), 1.0f), points));
+                img.Image.Mutate(o => o.DrawPolygon(new Pen(FromRGBA(col), 1.0f), points));
             }
 
             return true;

--- a/src/Peachpie.Library.Graphics/PhpGd2.cs
+++ b/src/Peachpie.Library.Graphics/PhpGd2.cs
@@ -426,7 +426,18 @@ namespace Peachpie.Library.Graphics
 
             try
             {
-                return new PhpGdImageResource(Image.Load<Rgba32>(image, out var format), format);
+                var img = Image.Load<Rgba32>(image, out var format);
+
+                // PHP will only preserve the first frame of a multi-frame image.
+                if (img.Frames.Count > 0)
+                {
+                    for (int i = 1; i < img.Frames.Count; i++)
+                    {
+                        img.Frames.RemoveFrame(i);
+                    }
+                }
+
+                return new PhpGdImageResource(img, format);
             }
             catch
             {
@@ -535,7 +546,20 @@ namespace Peachpie.Library.Graphics
             {
                 if (stream != null)
                 {
-                    try { img = Image.Load<Rgba32>(configuration, stream, out format); }
+                    try
+                    {
+                        img = Image.Load<Rgba32>(configuration, stream, out format);
+
+                        // PHP will only preserve the first frame of a multi-frame image.
+                        if (img.Frames.Count > 0)
+                        {
+                            for (int i = 1; i < img.Frames.Count; i++)
+                            {
+                                img.Frames.RemoveFrame(i);
+                            }
+                        }
+
+                    }
                     catch { }
                 }
             }

--- a/src/Peachpie.Library.Graphics/PhpGdImageResource.cs
+++ b/src/Peachpie.Library.Graphics/PhpGdImageResource.cs
@@ -56,9 +56,9 @@ namespace Peachpie.Library.Graphics
         internal Rgba32 transparentColor;
         internal bool IsTransparentColSet = false;
 
-        internal IBrush<Rgba32> styled = null;
-        internal IBrush<Rgba32> brushed = null;
-        internal IBrush<Rgba32> tiled = null;
+        internal IBrush styled = null;
+        internal IBrush brushed = null;
+        internal IBrush tiled = null;
 
         internal int LineThickness = 1;
 


### PR DESCRIPTION
- Updates all Sixlabors dependencies to the latest betas.
- Refactors graphics API calls to reflect changes.
- Adds temporary base `ImageProcessor<TPixel>` class to correctly handle per-frame manipulation.
- Changes loading behaviour to only preserve first frame of multi-frame image.
- Optimizes general EXIF metadata retrieval.

Note: I couldn't find unit tests for the graphics functionality so my changes are untested.