### PR TITLE
curl cookie `#HttpOnly_` support

### DIFF
--- a/src/Peachpie.Library.Network/CURLFunctions.cs
+++ b/src/Peachpie.Library.Network/CURLFunctions.cs
@@ -208,10 +208,11 @@ namespace Peachpie.Library.Network
 
             foreach (Cookie c in cookies)
             {
+                string prefix = c.HttpOnly ? "#HttpOnly_" : "";
                 string subdomainAccess = "TRUE";                    // Simplified
                 string secure = c.Secure.ToString().ToUpperInvariant();
                 long expires = (c.Expires.ToBinary() == 0) ? 0 : DateTimeUtils.UtcToUnixTimeStamp(c.Expires);
-                result.Add($"{c.Domain}\t{subdomainAccess}\t{c.Path}\t{secure}\t{expires}\t{c.Name}\t{c.Value}");
+                result.Add($"{prefix}{c.Domain}\t{subdomainAccess}\t{c.Path}\t{secure}\t{expires}\t{c.Name}\t{c.Value}");
             }
 
             return result;


### PR DESCRIPTION
### Description
This adds the missing `#HttpOnly_` prefix, see [ref](https://github.com/curl/curl/blob/9c1806ae4684ec5ef1aeb39bb9f15cece1c27256/lib/cookie.c#L1466-L1494).