### PR TITLE
implements 64 bit array keys

### DIFF
--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
@@ -2802,16 +2802,16 @@ namespace Pchp.CodeAnalysis.CodeGen
             return t;
         }
 
-        public void EmitIntStringKey(int key)
+        public void EmitIntStringKey(long key)
         {
-            _il.EmitIntConstant(key);
-            EmitCall(ILOpCode.Newobj, CoreMethods.Ctors.IntStringKey_int);
+            _il.EmitLongConstant(key);
+            EmitCall(ILOpCode.Newobj, CoreMethods.Ctors.IntStringKey_long);
         }
 
         public void EmitIntStringKey(string key)
         {
             // try convert string to integer as it is in PHP:
-            if (TryConvertToIntKey(key, out int ikey))
+            if (TryConvertToIntKey(key, out var ikey))
             {
                 EmitIntStringKey(ikey);
             }
@@ -2836,7 +2836,7 @@ namespace Pchp.CodeAnalysis.CodeGen
             }
         }
 
-        static bool TryConvertToIntKey(string key, out int ikey)
+        static bool TryConvertToIntKey(string key, out long ikey)
         {
             ikey = default;
 
@@ -2858,7 +2858,7 @@ namespace Pchp.CodeAnalysis.CodeGen
             }
 
 
-            return int.TryParse(key, out ikey);
+            return long.TryParse(key, out ikey);
         }
 
         public void EmitIntStringKey(BoundExpression expr)
@@ -2878,7 +2878,7 @@ namespace Pchp.CodeAnalysis.CodeGen
                 }
                 else if (constant.Value is long l)
                 {
-                    EmitIntStringKey((int)l);
+                    EmitIntStringKey(l);
                 }
                 else if (constant.Value is int i)
                 {
@@ -2886,7 +2886,7 @@ namespace Pchp.CodeAnalysis.CodeGen
                 }
                 else if (constant.Value is double d)
                 {
-                    EmitIntStringKey((int)d);
+                    EmitIntStringKey((long)d);
                 }
                 else if (constant.Value is bool b)
                 {

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundExpression.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundExpression.cs
@@ -2507,7 +2507,7 @@ namespace Pchp.CodeAnalysis.Semantics
             return cg.EmitCall(ILOpCode.Call, cg.CoreTypes.Operators.Method("GetListAccess", cg.CoreTypes.PhpValue));
         }
 
-        static void EmitItemAssign(CodeGenerator cg, KeyValuePair<BoundExpression, BoundReferenceExpression> item, int index, IPlace arrplace)
+        static void EmitItemAssign(CodeGenerator cg, KeyValuePair<BoundExpression, BoundReferenceExpression> item, long index, IPlace arrplace)
         {
             var target = item;
             if (target.Value == null)

--- a/src/Peachpie.CodeAnalysis/Symbols/CoreMembers.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/CoreMembers.cs
@@ -862,7 +862,7 @@ namespace Pchp.CodeAnalysis.Symbols
                 Blob = ct.PhpString_Blob.Ctor();
                 PhpArray = ct.PhpArray.Ctor();
                 PhpArray_int = ct.PhpArray.Ctor(ct.Int32);
-                IntStringKey_int = ct.IntStringKey.Ctor(ct.Int32);
+                IntStringKey_long = ct.IntStringKey.Ctor(ct.Long);
                 IntStringKey_string = ct.IntStringKey.Ctor(ct.String);
                 ScriptAttribute_string = ct.ScriptAttribute.Ctor(ct.String);
                 PhpTraitAttribute = ct.PhpTraitAttribute.Ctor();
@@ -885,7 +885,7 @@ namespace Pchp.CodeAnalysis.Symbols
                 PhpArray, PhpArray_int,
                 PhpString_Blob, PhpString_PhpString, PhpString_string_string, PhpString_PhpValue_Context,
                 Blob,
-                IntStringKey_int, IntStringKey_string,
+                IntStringKey_long, IntStringKey_string,
                 ScriptAttribute_string, PhpTraitAttribute, PharAttribute_string, PhpTypeAttribute_string_string, PhpFieldsOnlyCtorAttribute, PhpHiddenAttribute, NotNullAttribute,
                 DefaultValueAttribute_string,
                 ScriptDiedException, ScriptDiedException_Long, ScriptDiedException_PhpValue,

--- a/src/Peachpie.Library.Network/CURLConstants.cs
+++ b/src/Peachpie.Library.Network/CURLConstants.cs
@@ -589,7 +589,7 @@ namespace Peachpie.Library.Network
             return true;
         }
 
-        internal static bool TrySetOption(this CURLResource ch, int option, PhpValue value, RuntimeTypeHandle callerCtx)
+        internal static bool TrySetOption(this CURLResource ch, long option, PhpValue value, RuntimeTypeHandle callerCtx)
         {
             switch (option)
             {
@@ -750,15 +750,18 @@ namespace Peachpie.Library.Network
         /// <summary>
         /// Lookups the constant name (CURLOPT_*) with given value.
         /// </summary>
-        static string TryGetOptionName(int optionValue)
+        static string TryGetOptionName(long optionValue)
         {
-            var field = typeof(CURLConstants).GetFields()
-                .Where(f => f.Name.StartsWith("CURLOPT_", StringComparison.Ordinal))
-                .First(f =>
-                {
-                    var fval = f.GetRawConstantValue();
-                    return (fval is int i && i == optionValue);
-                });
+            var field = typeof(CURLConstants)
+                .GetFields()
+                .FirstOrDefault(f =>
+                    f.Name.StartsWith("CURLOPT_", StringComparison.Ordinal) &&
+                    f.GetRawConstantValue() switch
+                    {
+                        int i => i == optionValue,
+                        long l => l == optionValue,
+                        _ => false,
+                    });
 
             return field != null ? field.Name : optionValue.ToString();
         }

--- a/src/Peachpie.Library.XmlDom/SimpleXml.cs
+++ b/src/Peachpie.Library.XmlDom/SimpleXml.cs
@@ -1443,7 +1443,7 @@ namespace Peachpie.Library.XmlDom
         /// <summary>
         /// Returns the <paramref name="index"/>th sibling with the same local name and namespace URI or <B>null</B>.
         /// </summary>
-        private XmlElement GetSiblingForIndex(int index)
+        private XmlElement GetSiblingForIndex(long index)
         {
             if (index <= 0) return XmlElement;
 
@@ -1464,7 +1464,7 @@ namespace Peachpie.Library.XmlDom
         /// <summary>
         /// Returns the <param name="index"/>th attribute with the current namespace URI or<B>null</B>.
         /// </summary>
-        private XmlAttribute GetAttributeForIndex(int index)
+        private XmlAttribute GetAttributeForIndex(long index)
         {
             foreach (XmlAttribute attr in XmlElement.Attributes)
             {

--- a/src/Peachpie.Library/Processes.cs
+++ b/src/Peachpie.Library/Processes.cs
@@ -290,7 +290,7 @@ namespace Pchp.Library
                     return false;
                 }
 
-                int desc_no = e.CurrentKey.Integer;
+                var desc_no = e.CurrentKey.Integer;
 
                 switch (desc_no)
                 {
@@ -310,7 +310,7 @@ namespace Pchp.Library
             var descriptors_enum = descriptors.GetFastEnumerator();
             while (descriptors_enum.MoveNext())
             {
-                int desc_no = descriptors_enum.CurrentKey.Integer;
+                var desc_no = descriptors_enum.CurrentKey.Integer;
 
                 StreamAccessOptions access;
                 Stream stream;

--- a/src/Peachpie.Runtime/Dynamic/ConvertExpression.cs
+++ b/src/Peachpie.Runtime/Dynamic/ConvertExpression.cs
@@ -440,8 +440,8 @@ namespace Pchp.Core.Dynamic
         {
             var source = expr.Type;
 
-            if (source == typeof(int)) return Expression.New(Cache.IntStringKey.ctor_Int, expr);
-            if (source == typeof(long)) return Expression.New(Cache.IntStringKey.ctor_Int, Expression.Convert(expr, Cache.Types.Int[0]));
+            if (source == typeof(int)) return Expression.New(Cache.IntStringKey.ctor_Long, Expression.Convert(expr, Cache.Types.Long[0]));
+            if (source == typeof(long)) return Expression.New(Cache.IntStringKey.ctor_Long, expr);
             if (source == typeof(string)) return Expression.New(Cache.IntStringKey.ctor_String, expr);
 
             // following conversions may throw an exception

--- a/src/Peachpie.Runtime/Operators.cs
+++ b/src/Peachpie.Runtime/Operators.cs
@@ -420,40 +420,56 @@ namespace Pchp.Core
 
             public PhpValue GetItemValue(IntStringKey key)
             {
-                if (key.IsInteger)
-                    return PhpValue.FromClr(_array[key.Integer]);
+                if (key.IsInteger && Utilities.NumberUtils.IsInt32(key.Integer))
+                {
+                    return PhpValue.FromClr(_array[unchecked((int)key.Integer)]);
+                }
                 else
+                {
                     throw new ArgumentException(nameof(key));
+                }
             }
 
             public PhpValue GetItemValue(PhpValue index) => GetItemValue(index.ToIntStringKey());
 
             public void RemoveKey(IntStringKey key)
             {
-                if (key.IsInteger)
-                    _array.RemoveAt(key.Integer);
+                if (key.IsInteger && Utilities.NumberUtils.IsInt32(key.Integer))
+                {
+                    _array.RemoveAt(unchecked((int)key.Integer));
+                }
                 else
+                {
                     throw new ArgumentException(nameof(key));
+                }
             }
 
             public void RemoveKey(PhpValue index) => RemoveKey(index.ToIntStringKey());
 
             public void SetItemAlias(IntStringKey key, PhpAlias alias)
             {
-                if (key.IsInteger)
-                    _array[key.Integer] = ToObject(alias.Value);
+                if (key.IsInteger && Utilities.NumberUtils.IsInt32(key.Integer))
+                {
+                    _array[unchecked((int)key.Integer)] = ToObject(alias.Value);
+                }
                 else
+                {
                     throw new ArgumentException(nameof(key));
+                }
             }
 
             public void SetItemAlias(PhpValue index, PhpAlias alias) => SetItemAlias(index.ToIntStringKey(), alias);
 
             public void SetItemValue(IntStringKey key, PhpValue value)
             {
-                if (key.IsInteger)
-                    _array[key.Integer] = ToObject(value);
+                if (key.IsInteger && Utilities.NumberUtils.IsInt32(key.Integer))
+                {
+                    _array[unchecked((int)key.Integer)] = ToObject(value);
+                }
                 else
+                {
                     throw new ArgumentException(nameof(key));
+                }
             }
 
             public void SetItemValue(PhpValue index, PhpValue value) => SetItemValue(index.ToIntStringKey(), value);
@@ -610,11 +626,11 @@ namespace Pchp.Core
         /// <param name="value">String to be accessed as array.</param>
         /// <param name="index">Index.</param>
         /// <returns>Character on index or empty string if index is our of range.</returns>
-        public static string GetItemValue(string value, int index)
+        public static string GetItemValue(string value, long index)
         {
             return (value != null && index >= 0 && index < value.Length)
-                ? value[index].ToString()
-                : string.Empty;
+                ? value[unchecked((int)index)].ToString()
+                : string.Empty; // TODO: quiet ?
         }
 
         /// <summary>
@@ -622,9 +638,9 @@ namespace Pchp.Core
         /// </summary>
         public static string GetItemValue(string value, IntStringKey key)
         {
-            int index = key.IsInteger
+            var index = key.IsInteger
                 ? key.Integer
-                : (int)Convert.StringToLongInteger(key.String);
+                : Convert.StringToLongInteger(key.String);
 
             return GetItemValue(value, index);
         }
@@ -634,12 +650,12 @@ namespace Pchp.Core
         /// </summary>
         public static string GetItemValueOrNull(string value, IntStringKey key)
         {
-            int index = key.IsInteger
+            var index = key.IsInteger
                 ? key.Integer
-                : (int)Convert.StringToLongInteger(key.String);
+                : Convert.StringToLongInteger(key.String);
 
             return (value != null && index >= 0 && index < value.Length)
-                ? value[index].ToString()
+                ? value[unchecked((int)index)].ToString()
                 : null;
         }
 
@@ -648,9 +664,9 @@ namespace Pchp.Core
         /// </summary>
         public static string GetItemValue(string value, PhpValue index, bool quiet)
         {
-            if (Convert.TryToIntStringKey(index, out var key))
+            if (value != null && Convert.TryToIntStringKey(index, out var key))
             {
-                int i;
+                long i;
 
                 if (key.IsInteger)
                 {
@@ -660,12 +676,12 @@ namespace Pchp.Core
                 {
                     if (quiet) return null;
 
-                    i = (int)Convert.StringToLongInteger(key.String);
+                    i = Convert.StringToLongInteger(key.String);
                 }
 
-                if (value != null && i >= 0 && i < value.Length)
+                if (i >= 0 && i < value.Length)
                 {
-                    return value[i].ToString();
+                    return value[(int)i].ToString();
                 }
             }
 
@@ -838,7 +854,7 @@ namespace Pchp.Core
                 {
                     if (key.Integer >= 0 && key.Integer < list.Count)
                     {
-                        return PhpValue.FromClr(list[index.ToIntStringKey().Integer]);
+                        return PhpValue.FromClr(list[(int)key.Integer]);
                     }
                     else if (!quiet)
                     {

--- a/src/Peachpie.Runtime/PhpString.cs
+++ b/src/Peachpie.Runtime/PhpString.cs
@@ -1362,8 +1362,8 @@ namespace Pchp.Core
             /// </summary>
             PhpValue IPhpArray.GetItemValue(IntStringKey key)
             {
-                int index = key.IsInteger ? key.Integer : (int)Convert.StringToLongInteger(key.String);
-                return (index >= 0 && index < this.Length) ? this[index].AsValue() : PhpValue.Create(string.Empty);
+                var index = key.IsInteger ? key.Integer : Convert.StringToLongInteger(key.String);
+                return (index >= 0 && index < this.Length) ? this[(int)index].AsValue() : PhpValue.Create(string.Empty);
             }
 
             PhpValue IPhpArray.GetItemValue(PhpValue index)
@@ -1378,7 +1378,7 @@ namespace Pchp.Core
 
             void IPhpArray.SetItemValue(PhpValue index, PhpValue value)
             {
-                if (index.TryToIntStringKey(out IntStringKey key))
+                if (index.TryToIntStringKey(out var key))
                 {
                     ((IPhpArray)this).SetItemValue(key, value);
                 }
@@ -1393,8 +1393,15 @@ namespace Pchp.Core
             /// </summary>
             void IPhpArray.SetItemValue(IntStringKey key, PhpValue value)
             {
-                int index = key.IsInteger ? key.Integer : (int)Convert.StringToLongInteger(key.String);
-                this[index] = value;
+                var index = key.IsInteger ? key.Integer : Convert.StringToLongInteger(key.String);
+                if (NumberUtils.IsInt32(index))
+                {
+                    this[(int)index] = value;
+                }
+                else
+                {
+                    throw new NotSupportedException();
+                }
             }
 
             /// <summary>

--- a/src/Peachpie.Runtime/PhpValue.cs
+++ b/src/Peachpie.Runtime/PhpValue.cs
@@ -580,11 +580,11 @@ namespace Pchp.Core
                     return true;
 
                 case PhpTypeCode.Long:
-                    key = new IntStringKey(checked((int)Long));
+                    key = new IntStringKey(Long);
                     return true;
 
                 case PhpTypeCode.Double:
-                    key = new IntStringKey((int)Double);
+                    key = new IntStringKey((long)Double);
                     return true;
 
                 case PhpTypeCode.String:

--- a/src/Peachpie.Runtime/Utilities/NumberUtils.cs
+++ b/src/Peachpie.Runtime/Utilities/NumberUtils.cs
@@ -16,8 +16,7 @@ namespace Pchp.Core.Utilities
         /// </summary>
         public static bool IsInt32(long l)
         {
-            int i = unchecked((int)l);
-            return (i == l);
+            return l == unchecked((int)l);
         }
 
         /// <summary>Calculates the quotient of two 32-bit signed integers and also returns the remainder in an output parameter.</summary>

--- a/src/Tests/Peachpie.Runtime.Tests/OrderedDictionary.Tests.cs
+++ b/src/Tests/Peachpie.Runtime.Tests/OrderedDictionary.Tests.cs
@@ -149,7 +149,7 @@ namespace Peachpie.Runtime.Tests
 
             array.Shuffle(new Random());
 
-            var set = new HashSet<int>();
+            var set = new HashSet<long>();
 
             foreach (var pair in array)
             {
@@ -207,7 +207,7 @@ namespace Peachpie.Runtime.Tests
         {
             public int Compare(KeyValuePair<IntStringKey, PhpValue> x, KeyValuePair<IntStringKey, PhpValue> y)
             {
-                return x.Key.Integer - y.Key.Integer;
+                return x.Key.Integer.CompareTo(y.Key.Integer);
             }
         }
 


### PR DESCRIPTION
fixes https://github.com/peachpiecompiler/peachpie/issues/700

`PhpArray` (representing PHP's `array` type) now works with `Int64` keys.