### PR TITLE
sdk: translate composer versions to package versions

### DIFF
--- a/Peachpie.sln
+++ b/Peachpie.sln
@@ -52,6 +52,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Library.PDO", "Library.PDO", "{5DA1C2A7-6FFD-4E52-8E58-D3D082B84152}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{30104149-66C2-44B1-899F-F97E9ECA3860}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Peachpie.Runtime.Tests", "src\Tests\Peachpie.Runtime.Tests\Peachpie.Runtime.Tests.csproj", "{BD22AE7D-311C-46A2-B066-E937CBDD93EA}"
 EndProject
@@ -77,6 +80,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AspNetCore", "AspNetCore", "{82A72490-8B53-4A22-BB14-B0C4D6C83D67}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Peachpie.RequestHandler", "src\Peachpie.RequestHandler\Peachpie.RequestHandler.csproj", "{1FC901A6-0242-42A8-9F9A-8C4B1908AA34}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Peachpie.NET.SdkTests", "src\Tests\Peachpie.NET.SdkTests\Peachpie.NET.SdkTests.csproj", "{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -610,6 +615,26 @@ Global
 		{1FC901A6-0242-42A8-9F9A-8C4B1908AA34}.Release|x64.Build.0 = Release|Any CPU
 		{1FC901A6-0242-42A8-9F9A-8C4B1908AA34}.Release|x86.ActiveCfg = Release|Any CPU
 		{1FC901A6-0242-42A8-9F9A-8C4B1908AA34}.Release|x86.Build.0 = Release|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Debug|ARM.Build.0 = Debug|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Debug|x64.Build.0 = Debug|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Debug|x86.Build.0 = Debug|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Release|ARM.ActiveCfg = Release|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Release|ARM.Build.0 = Release|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Release|x64.ActiveCfg = Release|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Release|x64.Build.0 = Release|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Release|x86.ActiveCfg = Release|Any CPU
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -638,6 +663,7 @@ Global
 		{07CE395A-7873-40A5-A92D-019CAB583319} = {30D6D91F-A671-4E73-A571-5614500FDE0B}
 		{9E115135-F58A-4E00-95FE-A2ACF46C4713} = {82A72490-8B53-4A22-BB14-B0C4D6C83D67}
 		{8BE90675-F686-4327-8E13-BE3F7B540CF5} = {82A72490-8B53-4A22-BB14-B0C4D6C83D67}
+		{937F85EB-7F06-4A34-8C7D-BA3BF88E71AA} = {30104149-66C2-44B1-899F-F97E9ECA3860}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A0FC0FC5-DA92-4FD6-9841-D8ABF963E7AD}

--- a/src/Peachpie.NET.Sdk/ComposerTask.cs
+++ b/src/Peachpie.NET.Sdk/ComposerTask.cs
@@ -382,12 +382,6 @@ namespace Peachpie.NET.Sdk.Tools
             // convert composer version constraint to a floating version,
             // note, not all the constraints can be converted to a corresponding floating version.
 
-            // *
-            if (string.IsNullOrEmpty(value) || value == "*")
-            {
-                return "*";
-            }
-
             //>= 1.0
             //>= 1.0 <2.0
             //>= 1.0 <1.1 || >= 1.2
@@ -396,8 +390,14 @@ namespace Peachpie.NET.Sdk.Tools
             //~1.2.3
             //1 - 2
             //1.0.0 - 2.1.0
+            if (Versioning.ComposerVersionExpression.TryParse(value.AsSpan(), out var expression))
+            {
+                var version = expression.Evaluate();
+                return version.ToString();
+            }
 
-            return value;
+            // any
+            return "*";
         }
 
         string GetTags(JSONNode keywords)

--- a/src/Peachpie.NET.Sdk/Peachpie.NET.Sdk.csproj
+++ b/src/Peachpie.NET.Sdk/Peachpie.NET.Sdk.csproj
@@ -88,7 +88,7 @@
   </ItemGroup>
 
   <Target Name="PublishAll">
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="GeneratePackageOnBuild=false;" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="GeneratePackageOnBuild=false;Version=$(Version)" />
   </Target>
 
   <Target Name="SetPackageDependencies" BeforeTargets="GenerateNuspec" DependsOnTargets="PublishAll">

--- a/src/Peachpie.NET.Sdk/Versioning/ComposerVersion.cs
+++ b/src/Peachpie.NET.Sdk/Versioning/ComposerVersion.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Peachpie.NET.Sdk.Versioning
+{
+    /// <summary>
+    /// Single composer version.
+    /// </summary>
+    public struct ComposerVersion
+    {
+        /// <summary>
+        /// Version corresponding to <c>"*"</c>.
+        /// </summary>
+        public static ComposerVersion Any => new ComposerVersion { Major = -1, Minor = -1, Build = -1, };
+
+        /// <summary>
+        /// Major version component/
+        /// Value of <c>-1</c> represents not specified version component.
+        /// </summary>
+        public int Major { get; set; }
+
+        /// <summary>
+        /// Minor version component.
+        /// Value of <c>-1</c> represents not specified version component.
+        /// </summary>
+        public int Minor { get; set; }
+
+        /// <summary>
+        /// Build number component.
+        /// Value of <c>-1</c> represents not specified version component.
+        /// </summary>
+        public int Build { get; set; }
+
+        /// <summary>
+        /// Stability flag.
+        /// </summary>
+        public string Stability { get; set; }
+
+        /// <summary>
+        /// What parts of the version are specified.
+        /// </summary>
+        public int PartsCount => Major < 0 ? 0 : Minor < 0 ? 1 : Build < 0 ? 2 : 3;
+
+        /// <summary>
+        /// Gets value indicating the value is specified.
+        /// </summary>
+        public bool HasValue => Major != 0 || Minor != 0 || Build != 0 || Stability != null;
+
+        /// <summary>Returns string representation of the version.</summary>
+        public override string ToString()
+        {
+            return PartsCount switch
+            {
+                0 => "",
+                1 => $"{Major}",
+                2 => $"{Major}.{Minor}",
+                3 => $"{Major}.{Minor}.{Build}",
+                _ => throw new ArgumentException(),
+            };
+        }
+    }
+}

--- a/src/Peachpie.NET.Sdk/Versioning/ComposerVersionExpression.cs
+++ b/src/Peachpie.NET.Sdk/Versioning/ComposerVersionExpression.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Peachpie.NET.Sdk.Versioning
+{
+    /// <summary>
+    /// Version expression operators.
+    /// </summary>
+    public enum Operation
+    {
+        /// <summary>
+        /// Exact version.
+        /// </summary>
+        Exact,
+
+        /// <summary>
+        /// Logical and: ` ` or `,`.
+        /// </summary>
+        And,
+
+        /// <summary>
+        /// Logical or: `||`.
+        /// </summary>
+        Or,
+
+        /// <summary>
+        /// Version range: `A - B`
+        /// </summary>
+        Range,
+
+        /// <summary>
+        /// `&gt;`
+        /// </summary>
+        GreaterThan,
+
+        /// <summary>
+        /// `&gt;=`
+        /// </summary>
+        GreaterThanOrEqual,
+
+        /// <summary>
+        /// `&lt;`
+        /// </summary>
+        LessThan,
+
+        /// <summary>
+        /// `&lt;=`
+        /// </summary>
+        LessThanOrEqual,
+
+        /// <summary>
+        /// `!=`
+        /// </summary>
+        NotEqual,
+    }
+
+    /// <summary>
+    /// Version constraint expression.
+    /// </summary>
+    public abstract class ComposerVersionExpression
+    {
+        struct Tokens
+        {
+            public const char Wildcard = '*';
+            public const char VersionSeparator = '.';
+            public const char StabilitySeparator = '-';
+            public const string Range = " - ";
+            public readonly static char[] And = new[] { ' ', ',' };
+            public const string Or = "||";
+            public const char Lt = '<';
+            public const string Lte = "<=";
+            public const char Gt = '>';
+            public const string Gte = ">=";
+            public const string Ne = "!=";
+        }
+
+        /// <summary>
+        /// Expression operation.
+        /// </summary>
+        public abstract Operation Operation { get; }
+
+        /// <summary>
+        /// Parses the version expression.
+        /// </summary>
+        public static bool TryParse(string value, out ComposerVersionExpression expression)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Peachpie.NET.Sdk/Versioning/ComposerVersionExpression.cs
+++ b/src/Peachpie.NET.Sdk/Versioning/ComposerVersionExpression.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Peachpie.NET.Sdk.Versioning
 {
@@ -9,6 +11,11 @@ namespace Peachpie.NET.Sdk.Versioning
     /// </summary>
     public enum Operation
     {
+        /// <summary>
+        /// Nop.
+        /// </summary>
+        None,
+
         /// <summary>
         /// Exact version.
         /// </summary>
@@ -28,6 +35,16 @@ namespace Peachpie.NET.Sdk.Versioning
         /// Version range: `A - B`
         /// </summary>
         Range,
+
+        /// <summary>
+        /// ~A
+        /// </summary>
+        CaretVersionRange,
+
+        /// <summary>
+        /// ^A
+        /// </summary>
+        TildeVersionRange,
 
         /// <summary>
         /// `&gt;`
@@ -65,14 +82,16 @@ namespace Peachpie.NET.Sdk.Versioning
             public const char Wildcard = '*';
             public const char VersionSeparator = '.';
             public const char StabilitySeparator = '-';
-            public const string Range = " - ";
-            public readonly static char[] And = new[] { ' ', ',' };
-            public const string Or = "||";
+            public static ReadOnlySpan<char> Range => " - ".AsSpan();
+            public static ReadOnlySpan<char> Or => "||".AsSpan();
             public const char Lt = '<';
-            public const string Lte = "<=";
+            public static ReadOnlySpan<char> Lte => "<=".AsSpan();
             public const char Gt = '>';
-            public const string Gte = ">=";
-            public const string Ne = "!=";
+            public static ReadOnlySpan<char> Gte => ">=".AsSpan();
+            public static ReadOnlySpan<char> Ne => "!=".AsSpan();
+            public const char TildeVersion = '~';
+            public const char CaretVersion = '^';
+            public static readonly Regex AndRegex = new Regex(@"[^|]+([,\s]+)[^|]+", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
         }
 
         /// <summary>
@@ -83,7 +102,256 @@ namespace Peachpie.NET.Sdk.Versioning
         /// <summary>
         /// Parses the version expression.
         /// </summary>
-        public static bool TryParse(string value, out ComposerVersionExpression expression)
+        public static bool TryParse(string value, out ComposerVersionExpression expression) => TryParse(value.AsSpan(), out expression);
+
+        /// <summary>
+        /// Parses the version expression.
+        /// </summary>
+        public static bool TryParse(ReadOnlySpan<char> value, out ComposerVersionExpression expression)
+        {
+            expression = default;
+            value = value.Trim();
+
+            // ranges
+            var range = value.IndexOf(Tokens.Range); // regexp
+            if (range > 0 &&
+                value[range - 1] != '|' &&
+                range + Tokens.Range.Length < value.Length && value[range + Tokens.Range.Length] != '|')
+            {
+                // A - B
+                if (ComposerVersion.TryParse(value.Slice(0, range), out var fromversion) &&
+                    ComposerVersion.TryParse(value.Slice(range + Tokens.Range.Length), out var toversion))
+                {
+                    expression = new RangeExpression { From = fromversion, To = toversion, };
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else if (range == 0)
+            {
+                // - B
+                return false;
+            }
+
+            // AND, highest precedence
+            var and = Tokens.AndRegex.Match(value.ToString());
+            if (and.Success)
+            {
+                var cap = and.Groups[1];
+
+                if (TryParse(value.Slice(0, cap.Index), out var leftexpr) &&
+                    TryParse(value.Slice(cap.Index + cap.Length), out var rightexpr))
+                {
+                    expression = new AndExpression { Left = leftexpr, Right = rightexpr, };
+                    return true;
+                }
+            }
+
+            // OR
+            var or = value.IndexOf(Tokens.Or);
+            if (or > 0)
+            {
+                // A || B
+                if (TryParse(value.Slice(0, or), out var left) &&
+                    TryParse(value.Slice(or + Tokens.Or.Length), out var right))
+                {
+                    expression = new OrExpression { Left = left, Right = right, };
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else if (or == 0)
+            {
+                // invalid
+                return false;
+            }
+
+            //
+            if (value.IsEmpty)
+            {
+                return false;
+            }
+
+            // unary version ranges
+            Operation op;
+
+            if (value[0] == Tokens.CaretVersion)
+            {
+                op = Operation.CaretVersionRange;
+                value = value.Slice(1);
+            }
+            else if (value[0] == Tokens.TildeVersion)
+            {
+                op = Operation.TildeVersionRange;
+                value = value.Slice(1);
+            }
+            else if (value.StartsWith(Tokens.Lte))
+            {
+                op = Operation.LessThanOrEqual;
+                value = value.Slice(Tokens.Lte.Length);
+            }
+            else if (value.StartsWith(Tokens.Gte))
+            {
+                op = Operation.GreaterThanOrEqual;
+                value = value.Slice(Tokens.Gte.Length);
+            }
+            else if (value.StartsWith(Tokens.Ne))
+            {
+                op = Operation.NotEqual;
+                value = value.Slice(Tokens.Ne.Length);
+            }
+            else if (value[0] == Tokens.Lt)
+            {
+                op = Operation.LessThan;
+                value = value.Slice(1);
+            }
+            else if (value[0] == Tokens.Gt)
+            {
+                op = Operation.GreaterThan;
+                value = value.Slice(1);
+            }
+            else
+            {
+                op = Operation.Exact;
+            }
+
+            if (ComposerVersion.TryParse(value, out var version))
+            {
+                if (op == Operation.Exact)
+                {
+                    expression = new ExactVersionExpression { Version = version };
+                }
+                else
+                {
+                    expression = new UnaryExpression(op) { Version = version, };
+                }
+
+                return true;
+            }
+
+            //
+            return false;
+        }
+
+        /// <summary>
+        /// Evaluates the expression to a corresponding PackageReference floating version.
+        /// </summary>
+        public abstract FloatingVersion Evaluate();
+    }
+
+    [DebuggerDisplay("{Operation} {Version}")]
+    class UnaryExpression : ComposerVersionExpression
+    {
+        public override Operation Operation => _op;
+        readonly Operation _op;
+
+        public UnaryExpression(Operation op)
+        {
+            _op = op;
+        }
+
+        public ComposerVersion Version { get; set; }
+
+        public override FloatingVersion Evaluate()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    [DebuggerDisplay("{Left} {Operation} {Right}")]
+    abstract class BinaryExpression : ComposerVersionExpression
+    {
+        public ComposerVersionExpression Left { get; set; }
+
+        public ComposerVersionExpression Right { get; set; }
+
+        public override FloatingVersion Evaluate() => Evaluate(Left.Evaluate(), Right.Evaluate());
+
+        protected abstract FloatingVersion Evaluate(FloatingVersion left, FloatingVersion right);
+    }
+
+    sealed class AndExpression : BinaryExpression
+    {
+        public override Operation Operation => Operation.And;
+
+        protected override FloatingVersion Evaluate(FloatingVersion left, FloatingVersion right)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    sealed class OrExpression : BinaryExpression
+    {
+        public override Operation Operation => Operation.Or;
+
+        protected override FloatingVersion Evaluate(FloatingVersion left, FloatingVersion right)
+        {
+            // cannot be translated,
+            // so we'll just merge the ranges
+
+            throw new NotImplementedException();
+        }
+    }
+
+    [DebuggerDisplay("{Version}")]
+    sealed class ExactVersionExpression : ComposerVersionExpression
+    {
+        public override Operation Operation => Operation.Exact;
+
+        public ComposerVersion Version { get; set; }
+
+        public override FloatingVersion Evaluate()
+        {
+            // has asterisks?
+            if (Version.PartsCount == 0 || Version.PartsCount >= 1 && Version.Major < 0)
+            {
+                // *
+                return new FloatingVersion();
+            }
+
+            if (Version.PartsCount >= 2 && Version.Minor < 0)
+            {
+                // Major.* => [Major.0.0,Major+1,0,0)
+                return new FloatingVersion
+                {
+                    LowerBound = new ComposerVersion(Version.Major, 0, 0),
+                    UpperBound = new ComposerVersion(Version.Major + 1, 0, 0),
+                    UpperBoundExclusive = true,
+                };
+            }
+
+            if (Version.PartsCount >= 3 && Version.Build < 0)
+            {
+                // Major.Minor.* => [Major.Minor.0,Major,Minor+1,0)
+                return new FloatingVersion
+                {
+                    LowerBound = new ComposerVersion(Version.Major, Version.Minor, 0),
+                    UpperBound = new ComposerVersion(Version.Major, Version.Minor + 1, 0),
+                    UpperBoundExclusive = true,
+                };
+            }
+
+            // exact version
+            return new FloatingVersion { LowerBound = Version, UpperBound = Version, };
+        }
+    }
+
+    [DebuggerDisplay("{From} - {To}")]
+    sealed class RangeExpression : ComposerVersionExpression
+    {
+        public override Operation Operation => Operation.Range;
+
+        public ComposerVersion From { get; set; }
+
+        public ComposerVersion To { get; set; }
+
+        public override FloatingVersion Evaluate()
         {
             throw new NotImplementedException();
         }

--- a/src/Peachpie.NET.Sdk/Versioning/FloatingVersion.cs
+++ b/src/Peachpie.NET.Sdk/Versioning/FloatingVersion.cs
@@ -13,15 +13,71 @@ namespace Peachpie.NET.Sdk.Versioning
         public ComposerVersion LowerBound { get; set; }
 
         /// <summary></summary>
-        public bool LowerBoundInclusive { get; set; }
+        public bool LowerBoundExclusive { get; set; }
 
         /// <summary></summary>
         public ComposerVersion UpperBound { get; set; }
 
         /// <summary></summary>
-        public bool UpperBoundInclusive { get; set; }
+        public bool UpperBoundExclusive { get; set; }
 
-        // And
-        // Or
+        /// <summary>
+        /// Gets corresponding package floating version string.
+        /// </summary>
+        public override string ToString()
+        {
+            if (LowerBound.HasValue || UpperBound.HasValue)
+            {
+                var value = new StringBuilder();
+
+                if (!UpperBound.HasValue && !LowerBoundExclusive)
+                {
+                    // version
+                    return LowerBound.ToString();// + (LowerBound.Stability != null ? "-*" : "");
+                }
+
+                value.Append(LowerBoundExclusive ? '(' : '[');
+
+                if (LowerBound.HasValue)
+                {
+                    value.Append(LowerBound.ToString());
+                    if (LowerBound.Stability != null)
+                    {
+                        if (LowerBound.PartsCount == 0) value.Append('*');
+                        //value.Append("-*");
+                    }
+
+                    if (LowerBound == UpperBound)
+                    {
+                        // [version]
+                        value.Append("]");
+                        return value.ToString();
+                    }
+                }
+
+
+                value.Append(',');
+
+                if (UpperBound.HasValue)
+                {
+                    value.Append(UpperBound.ToString());
+
+                    if (UpperBound.Stability != null)
+                    {
+                        if (UpperBound.PartsCount == 0) value.Append('*');
+                        //value.Append("-*");
+                    }
+                }
+
+                value.Append(UpperBoundExclusive ? ')' : ']');
+
+                // [lower,upper]
+                return value.ToString();
+            }
+            else
+            {
+                return "*";
+            }
+        }
     }
 }

--- a/src/Peachpie.NET.Sdk/Versioning/FloatingVersion.cs
+++ b/src/Peachpie.NET.Sdk/Versioning/FloatingVersion.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Peachpie.NET.Sdk.Versioning
+{
+    /// <summary>
+    /// Package reference floating version.
+    /// </summary>
+    public class FloatingVersion
+    {
+        /// <summary></summary>
+        public ComposerVersion LowerBound { get; set; }
+
+        /// <summary></summary>
+        public bool LowerBoundInclusive { get; set; }
+
+        /// <summary></summary>
+        public ComposerVersion UpperBound { get; set; }
+
+        /// <summary></summary>
+        public bool UpperBoundInclusive { get; set; }
+
+        // And
+        // Or
+    }
+}

--- a/src/Peachpie.NET.Sdk/Versioning/FloatingVersion.cs
+++ b/src/Peachpie.NET.Sdk/Versioning/FloatingVersion.cs
@@ -33,7 +33,7 @@ namespace Peachpie.NET.Sdk.Versioning
                 if (!UpperBound.HasValue && !LowerBoundExclusive)
                 {
                     // version
-                    return LowerBound.ToString();// + (LowerBound.Stability != null ? "-*" : "");
+                    return $"[{LowerBound},]";// + (LowerBound.Stability != null ? "-*" : "");
                 }
 
                 value.Append(LowerBoundExclusive ? '(' : '[');
@@ -47,14 +47,13 @@ namespace Peachpie.NET.Sdk.Versioning
                         //value.Append("-*");
                     }
 
-                    if (LowerBound == UpperBound)
+                    if (UpperBound.HasValue && !LowerBoundExclusive && LowerBound == UpperBound)
                     {
                         // [version]
                         value.Append("]");
                         return value.ToString();
                     }
                 }
-
 
                 value.Append(',');
 

--- a/src/Tests/Peachpie.NET.SdkTests/ComposerVersionTest.cs
+++ b/src/Tests/Peachpie.NET.SdkTests/ComposerVersionTest.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Peachpie.NET.Sdk.Versioning;
+
+namespace Peachpie.Runtime.Tests
+{
+    [TestClass]
+    public class ComposerVersionTest
+    {
+        [TestMethod]
+        public void ParseTest()
+        {
+            Assert.IsTrue(ComposerVersion.TryParse("1.2.3", out var ver));
+            Assert.AreEqual("1.2.3", ver.ToString());
+
+            Assert.IsTrue(ComposerVersion.TryParse("1.2.*", out ver));
+            Assert.AreEqual("1.2.*", ver.ToString());
+
+            Assert.IsTrue(ComposerVersion.TryParse("1.2", out ver));
+            Assert.AreEqual("1.2", ver.ToString());
+
+            Assert.IsTrue(ComposerVersionExpression.TryParse("1.2.3", out var expr));
+            Assert.AreEqual("[1.2.3]", expr.Evaluate().ToString());
+
+            Assert.IsTrue(ComposerVersionExpression.TryParse("1.2.*", out expr));
+            Assert.AreEqual("[1.2.0,1.3.0)", expr.Evaluate().ToString());
+
+            Assert.IsTrue(ComposerVersionExpression.TryParse(">=1.0 <2.0", out expr));
+            Assert.AreEqual("[1.0.0,2.0.0)", expr.Evaluate().ToString());
+        }
+    }
+}

--- a/src/Tests/Peachpie.NET.SdkTests/ComposerVersionTest.cs
+++ b/src/Tests/Peachpie.NET.SdkTests/ComposerVersionTest.cs
@@ -8,7 +8,7 @@ namespace Peachpie.Runtime.Tests
     public class ComposerVersionTest
     {
         [TestMethod]
-        public void ParseTest()
+        public void VersionParseTest()
         {
             Assert.IsTrue(ComposerVersion.TryParse("1.2.3", out var ver));
             Assert.AreEqual("1.2.3", ver.ToString());
@@ -18,15 +18,43 @@ namespace Peachpie.Runtime.Tests
 
             Assert.IsTrue(ComposerVersion.TryParse("1.2", out ver));
             Assert.AreEqual("1.2", ver.ToString());
+        }
 
+        [TestMethod]
+        public void FloatingVersionTest()
+        {
             Assert.IsTrue(ComposerVersionExpression.TryParse("1.2.3", out var expr));
             Assert.AreEqual("[1.2.3]", expr.Evaluate().ToString());
 
-            Assert.IsTrue(ComposerVersionExpression.TryParse("1.2.*", out expr));
-            Assert.AreEqual("[1.2.0,1.3.0)", expr.Evaluate().ToString());
+            Assert.IsTrue(ComposerVersionExpression.TryParse("1.4.*", out expr));
+            Assert.AreEqual("[1.4.0,1.5.0)", expr.Evaluate().ToString());
 
             Assert.IsTrue(ComposerVersionExpression.TryParse(">=1.0 <2.0", out expr));
             Assert.AreEqual("[1.0.0,2.0.0)", expr.Evaluate().ToString());
+
+            Assert.IsTrue(ComposerVersionExpression.TryParse(">1.2", out expr));
+            Assert.AreEqual("(1.2.0,]", expr.Evaluate().ToString());
+
+            Assert.IsTrue(ComposerVersionExpression.TryParse(">=1.2", out expr));
+            Assert.AreEqual("[1.2.0,]", expr.Evaluate().ToString());
+
+            Assert.IsTrue(ComposerVersionExpression.TryParse("<1.3", out expr));
+            Assert.AreEqual("[,1.3.0)", expr.Evaluate().ToString());
+
+            Assert.IsTrue(ComposerVersionExpression.TryParse("1 - 2", out expr));
+            Assert.AreEqual("[1.0.0,3.0.0)", expr.Evaluate().ToString());
+
+            Assert.IsTrue(ComposerVersionExpression.TryParse("~1.3", out expr));
+            Assert.AreEqual("[1.3.0,2.0.0)", expr.Evaluate().ToString());
+
+            Assert.IsTrue(ComposerVersionExpression.TryParse("^1.2.3", out expr));
+            Assert.AreEqual("[1.2.3,2.0.0)", expr.Evaluate().ToString());
+
+            Assert.IsTrue(ComposerVersionExpression.TryParse("^0.3", out expr));
+            Assert.AreEqual("[0.3.0,0.4.0)", expr.Evaluate().ToString());
+
+            Assert.IsTrue(ComposerVersionExpression.TryParse("1.0.*", out expr));
+            Assert.AreEqual("[1.0.0,1.1.0)", expr.Evaluate().ToString());
         }
     }
 }

--- a/src/Tests/Peachpie.NET.SdkTests/Peachpie.NET.SdkTests.csproj
+++ b/src/Tests/Peachpie.NET.SdkTests/Peachpie.NET.SdkTests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>    
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Peachpie.NET.Sdk\Peachpie.NET.Sdk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
this PR adds a translation of `composer.json` to corresponding PackageReference items.

- `"require"` element is processes
- `"ext-<extension>"` is translated to corresponding PackageReference
- `"php-"` is ignored
- `"vendor/name"` is translated to PackageReference `vendor.name`
- version constraints are parsed and translated to best matching floating version expression

Use of requirements from `composer.json` can be enabled by setting property `$(ComposerDependencies)` to `true`