### PR TITLE
"sockets" implementation

### DIFF
--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -322,7 +322,30 @@ namespace Peachpie.Library.Network
             return false;
         }
 
-        //socket_create_listen — Opens a socket on port to accept connections
+        /// <summary>
+        /// Opens a socket on port to accept connections.
+        /// </summary>
+        [return: CastToFalse]
+        public static PhpResource socket_create_listen(int port, int backlog = 128)
+        {
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+            try
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Any, port));
+                socket.Listen(backlog);
+
+                return new SocketResource(socket);
+            }
+            catch (SocketException ex)
+            {
+                HandleException(null, null, ex);
+            }
+
+            //
+            return null; // FALSE
+        }
+
         //socket_create_pair — Creates a pair of indistinguishable sockets and stores them in an array
 
         /// <summary>

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -514,7 +515,6 @@ namespace Peachpie.Library.Network
             }
         }
 
-
         //socket_import_stream — Import a stream
 
         /// <summary>
@@ -542,7 +542,6 @@ namespace Peachpie.Library.Network
             //
             return (int)SocketError.Success;
         }
-
 
         /// <summary>
         /// Listens for a connection on a socket.
@@ -634,7 +633,19 @@ namespace Peachpie.Library.Network
         //socket_recv — Receives data from a connected socket
         //socket_recvfrom — Receives data from a socket whether or not it is connection-oriented
         //socket_recvmsg — Read a message
-        //socket_select — Runs the select() system call on the given arrays of sockets with a specified timeout
+
+        ///// <summary>
+        ///// Runs the select() system call on the given arrays of sockets with a specified timeout.
+        ///// </summary>
+        //public static int socket_select(ref PhpArray read, ref PhpArray write, ref PhpArray except, int tv_sec, int tv_usec = 0)
+        //{
+        //    int micro = (tv_sec >= 0 || tv_usec > 0) ? (tv_sec * 1_000_000 + tv_usec) : -1;
+
+            
+            
+        //    throw new NotImplementedException();
+        //}
+
         //socket_send — Sends data to a connected socket
         //socket_sendmsg — Send a message
         //socket_sendto — Sends a message to a socket, whether it is connected or not

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -652,7 +652,38 @@ namespace Peachpie.Library.Network
         public static bool socket_setopt(PhpResource socket, SocketOptionLevel level, SocketOptionName option, PhpValue option_value)
             => socket_set_option(socket, level, option, option_value);
 
-        //socket_shutdown — Shuts down a socket for receiving, sending, or both
+        /// <summary>
+        /// Shuts down a socket for receiving, sending, or both.
+        /// </summary>
+        /// <param name="socket"></param>
+        /// <param name="how">
+        /// 0	Shutdown socket reading<br/>
+        /// 1	Shutdown socket writing<br/>
+        /// 2	Shutdown socket reading and writing<br/>
+        /// </param>
+        public static bool socket_shutdown(PhpResource socket, SocketShutdown how = SocketShutdown.Both)
+        {
+            Debug.Assert((int)SocketShutdown.Receive == 0);
+            Debug.Assert((int)SocketShutdown.Send == 1);
+            Debug.Assert((int)SocketShutdown.Both == 2);
+
+            var s = SocketResource.GetValid(socket);
+            if (s != null)
+            {
+                try
+                {
+                    s.Socket.Shutdown(how);
+                    return true;
+                }
+                catch (SocketException ex)
+                {
+                    HandleException(null, s, ex);
+                }
+            }
+
+            //
+            return false;
+        }
 
         //socket_strerror — Return a string describing a socket error
         public static string socket_strerror(SocketError errno)

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -226,7 +226,25 @@ namespace Peachpie.Library.Network
             return false;
         }
 
-        //socket_clear_error — Clears the error on the socket or the last error code
+        /// <summary>
+        /// Clears the error on the socket or the last error code.
+        /// </summary>
+        public static void socket_clear_error(Context ctx, PhpResource socket = null)
+        {
+            if (socket != null)
+            {
+                var s = SocketResource.GetValid(socket);
+                if (s != null)
+                {
+                    // get error on the socket resource
+                    s.LastError = SocketError.Success;
+                }
+            }
+            else
+            {            // get last SocketException from context
+                ctx.SetProperty<SocketException>(null);
+            }
+        }
 
         /// <summary>
         /// Closes a socket resource.
@@ -254,6 +272,8 @@ namespace Peachpie.Library.Network
             var endpoint = BindEndPoint(s.Socket.AddressFamily, address, port);
             if (endpoint != null)
             {
+                // TODO: If the socket is non-blocking then return FALSE with an error Operation now in progress.
+
                 try
                 {
                     s.Socket.Connect(endpoint);

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -116,6 +116,45 @@ namespace Peachpie.Library.Network
         public const int SOL_TCP = (int)ProtocolType.Tcp;
         public const int SOL_UDP = (int)ProtocolType.Udp;
 
+        public const int SO_FREE = 8;
+        public const int SO_NOSERVER = 16;
+        public const int SO_DEBUG = 1;
+        public const int SO_REUSEADDR = 4;
+        public const int SO_KEEPALIVE = 8;
+        public const int SO_DONTROUTE = 16;
+        public const int SO_LINGER = 128;
+        public const int SO_BROADCAST = 32;
+        public const int SO_OOBINLINE = 256;
+        public const int SO_SNDBUF = 4097;
+        public const int SO_RCVBUF = 4098;
+        public const int SO_SNDLOWAT = 4099;
+        public const int SO_RCVLOWAT = 4100;
+        public const int SO_SNDTIMEO = 4101;
+        public const int SO_RCVTIMEO = 4102;
+        public const int SO_TYPE = 4104;
+        public const int SO_ERROR = 4103;
+
+        public enum SocketOption
+        {
+            FREE = SO_FREE,
+            NOSERVER = SO_NOSERVER,
+            DEBUG = SO_DEBUG,
+            REUSEADDR = SO_REUSEADDR,
+            KEEPALIVE = SO_KEEPALIVE,
+            DONTROUTE = SO_DONTROUTE,
+            LINGER = SO_LINGER,
+            BROADCAST = SO_BROADCAST,
+            OOBINLINE = SO_OOBINLINE,
+            SNDBUF = SO_SNDBUF,
+            RCVBUF = SO_RCVBUF,
+            SNDLOWAT = SO_SNDLOWAT,
+            RCVLOWAT = SO_RCVLOWAT,
+            SNDTIMEO = SO_SNDTIMEO,
+            RCVTIMEO = SO_RCVTIMEO,
+            TYPE = SO_TYPE,
+            ERROR = SO_ERROR,
+        }
+
         #endregion
 
         static void HandleException(Context ctx, SocketResource resource, Exception ex)

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -448,7 +448,38 @@ namespace Peachpie.Library.Network
         /// </summary>
         public static PhpValue socket_getopt(PhpResource socket, SocketOptionLevel level, SocketOptionName option) => socket_get_option(socket, level, option);
 
-        //socket_getpeername — Queries the remote side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type
+        /// <summary>
+        /// Queries the remote side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type.
+        /// </summary>
+        public static bool socket_getpeername(PhpResource socket, out string addr) => socket_getpeername(socket, out addr, out _);
+
+        /// <summary>
+        /// Queries the remote side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type.
+        /// </summary>
+        public static bool socket_getpeername(PhpResource socket, out string addr, out int port)
+        {
+            addr = null;
+            port = 0;
+
+            var s = SocketResource.GetValid(socket);
+            if (s == null)
+            {
+                return false;
+            }
+
+            var ep = s.Socket.RemoteEndPoint;
+            if (ep is IPEndPoint ipep)
+            {
+                addr = ipep.Address.ToString();
+                port = ipep.Port;
+                return true;
+            }
+            else
+            {
+                PhpException.ArgumentValueNotSupported(nameof(AddressFamily), s.Socket.AddressFamily);
+                return false;
+            }
+        }
 
         /// <summary>
         /// Queries the local side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type.

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -50,34 +50,6 @@ namespace Peachpie.Library.Network
         public SocketError LastError { get; set; } = SocketError.Success;
     }
 
-    #region Helpers
-
-    /// <summary>
-    /// Helper socket methods.
-    /// </summary>
-    static class SocketsExtension
-    {
-        public static AddressFamily GetAddressFamily(this Sockets.PhpAddressFamily af) => af switch
-        {
-            Sockets.PhpAddressFamily.UNIX => AddressFamily.Unix,
-            Sockets.PhpAddressFamily.INET => AddressFamily.InterNetwork,
-            Sockets.PhpAddressFamily.INET6 => AddressFamily.InterNetworkV6,
-            _ => default,
-        };
-
-        public static SocketType GetSocketType(this Sockets.PhpSocketType type) => type switch
-        {
-            Sockets.PhpSocketType.STREAM => SocketType.Stream,
-            Sockets.PhpSocketType.DGRAM => SocketType.Dgram,
-            Sockets.PhpSocketType.RAW => SocketType.Raw,
-            Sockets.PhpSocketType.SEQPACKET => SocketType.Seqpacket,
-            Sockets.PhpSocketType.RDM => SocketType.Rdm,
-            _ => default,
-        };
-    }
-
-    #endregion
-
     /// <summary>
     /// "socket" extension functions.
     /// </summary>
@@ -86,37 +58,15 @@ namespace Peachpie.Library.Network
     {
         #region Constants
 
-        public const int AF_UNIX = 1;
-        public const int AF_INET = 2;
-        public const int AF_INET6 = 23;
-
-        /// <summary>
-        /// Socket family to be used for creating new sockets.
-        /// </summary>
-        public enum PhpAddressFamily
-        {
-            UNIX = AF_UNIX,
-            INET = AF_INET,
-            INET6 = AF_INET6,
-        }
+        public const int AF_UNIX = (int)AddressFamily.Unix; // 1
+        public const int AF_INET = (int)AddressFamily.InterNetwork; // 2;
+        public const int AF_INET6 = (int)AddressFamily.InterNetworkV6; // 23;
 
         public const int SOCK_STREAM = (int)SocketType.Stream; // 1
         public const int SOCK_DGRAM = (int)SocketType.Dgram; // 2
         public const int SOCK_RAW = (int)SocketType.Raw; // 3
         public const int SOCK_RDM = (int)SocketType.Rdm; // 4
         public const int SOCK_SEQPACKET = (int)SocketType.Seqpacket; // 5
-
-        /// <summary>
-        /// Socket underlying communication type.
-        /// </summary>
-        public enum PhpSocketType
-        {
-            STREAM = SOCK_STREAM,
-            DGRAM = SOCK_DGRAM,
-            RAW = SOCK_RAW,
-            SEQPACKET = SOCK_SEQPACKET,
-            RDM = SOCK_RDM,
-        }
 
         public const int SOL_SOCKET = (int)SocketOptionLevel.Socket; // 65535
         public const int SOL_TCP = (int)SocketOptionLevel.Tcp; // 6
@@ -356,10 +306,10 @@ namespace Peachpie.Library.Network
         /// <param name="type"></param>
         /// <param name="protocol"></param>
         /// <returns></returns>
-        public static PhpResource socket_create(PhpAddressFamily domain, PhpSocketType type, ProtocolType protocol)
+        public static PhpResource socket_create(AddressFamily domain, SocketType type, ProtocolType protocol)
         {
             // TODO: validate arguments and return FALSE
-            return new SocketResource(new Socket(domain.GetAddressFamily(), type.GetSocketType(), protocol));
+            return new SocketResource(new Socket(domain, type, protocol));
         }
 
         //socket_export_stream — Export a socket extension resource into a stream that encapsulates a socket

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -695,8 +695,40 @@ namespace Peachpie.Library.Network
         //socket_send — Sends data to a connected socket
         //socket_sendmsg — Send a message
         //socket_sendto — Sends a message to a socket, whether it is connected or not
-        //socket_set_block — Sets blocking mode on a socket resource
-        //socket_set_nonblock — Sets nonblocking mode for file descriptor fd
+
+        /// <summary>
+        /// Sets blocking mode.
+        /// </summary>
+        public static bool socket_set_block(PhpResource socket) => SetBlocking(socket, true);
+
+        /// <summary>
+        /// Sets nonblocking mode.
+        /// </summary>
+        public static bool socket_set_nonblock(PhpResource socket) => SetBlocking(socket, false);
+
+        /// <summary>
+        /// Sets <see cref="Socket.Blocking"/> on <see cref="SocketResource.Socket"/>.
+        /// </summary>
+        static bool SetBlocking(PhpResource socket, bool blocking)
+        {
+            var s = SocketResource.GetValid(socket);
+            if (s == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                s.Socket.Blocking = blocking;
+            }
+            catch (SocketException ex)
+            {
+                HandleException(null, s, ex);
+                return false;
+            }
+
+            return true;
+        }
 
         /// <summary>
         /// Sets socket options for the socket.
@@ -800,7 +832,9 @@ namespace Peachpie.Library.Network
             return false;
         }
 
-        //socket_strerror — Return a string describing a socket error
+        /// <summary>
+        /// Return a string describing a socket error.
+        /// </summary>
         public static string socket_strerror(SocketError errno)
         {
             // TODO: get full error message

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -135,7 +135,35 @@ namespace Peachpie.Library.Network
             }
         }
 
-        //socket_accept — Accepts a connection on a socket
+        /// <summary>
+        /// Accepts a connection on a socket.
+        /// </summary>
+        /// <returns>Returns a new socket resource on success, or FALSE on error.</returns>
+        [return: CastToFalse]
+        public static PhpResource socket_accept(PhpResource socket )
+        {
+            var s = SocketResource.GetValid(socket);
+            if (s == null)
+            {
+                return null;// FALSE
+            }
+
+            if (s.Socket.Connected)
+            {
+                throw new InvalidOperationException("socket connected");
+                //return null; // FALSE
+            }
+
+            try
+            {
+                return new SocketResource(s.Socket.Accept());
+            }
+            catch (SocketException ex)
+            {
+                HandleException(null, s, ex);
+                return null;
+            }
+        }
 
         //socket_addrinfo_bind — Create and bind to a socket from a given addrinfo
         //socket_addrinfo_connect — Create and connect to a socket from a given addrinfo

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Text;
+using Pchp.Core;
+using Pchp.Core.Resources;
+
+namespace Peachpie.Library.Network
+{
+    /// <summary>
+    /// PHP socket resource.
+    /// </summary>
+    class SocketResource : PhpResource
+    {
+        public Socket Socket { get; }
+
+        public SocketResource(Socket socket) : base("socket")
+        {
+            this.Socket = socket ?? throw new ArgumentNullException(nameof(socket));
+        }
+
+        protected override void FreeManaged()
+        {
+            this.Socket.Close();
+        }
+
+        public static SocketResource GetValid(PhpResource resource)
+        {
+            if (resource is SocketResource s && s.IsValid)
+            {
+                return s;
+            }
+            else
+            {
+                PhpException.Throw(PhpError.Warning, ErrResources.invalid_socket_resource);
+                return null;
+            }
+        }
+    }
+
+    #region Helpers
+
+    /// <summary>
+    /// Helper socket methods.
+    /// </summary>
+    static class SocketsExtension
+    {
+        public static AddressFamily GetAddressFamily(this Sockets.PhpAddressFamily af) => af switch
+        {
+            Sockets.PhpAddressFamily.UNIX => AddressFamily.Unix,
+            Sockets.PhpAddressFamily.INET => AddressFamily.InterNetwork,
+            Sockets.PhpAddressFamily.INET6 => AddressFamily.InterNetworkV6,
+            _ => default,
+        };
+
+        public static SocketType GetSocketType(this Sockets.PhpSocketType type) => type switch
+        {
+            Sockets.PhpSocketType.STREAM => SocketType.Stream,
+            Sockets.PhpSocketType.DGRAM => SocketType.Dgram,
+            Sockets.PhpSocketType.RAW => SocketType.Raw,
+            Sockets.PhpSocketType.SEQPACKET => SocketType.Seqpacket,
+            Sockets.PhpSocketType.RDM => SocketType.Rdm,
+            _ => default,
+        };
+    }
+
+    #endregion
+
+    /// <summary>
+    /// "socket" extension functions.
+    /// </summary>
+    [PhpExtension("sockets")]
+    public static class Sockets
+    {
+        #region Constants
+
+        public const int AF_UNIX = 1;
+        public const int AF_INET = 2;
+        public const int AF_INET6 = 23;
+
+        /// <summary>
+        /// Socket family to be used for creating new sockets.
+        /// </summary>
+        public enum PhpAddressFamily
+        {
+            UNIX = AF_UNIX,
+            INET = AF_INET,
+            INET6 = AF_INET6,
+        }
+
+        public const int SOCK_STREAM = 1;
+        public const int SOCK_DGRAM = 2;
+        public const int SOCK_RAW = 3;
+        public const int SOCK_SEQPACKET = 5;
+        public const int SOCK_RDM = 4;
+
+        /// <summary>
+        /// Socket underlying communication type.
+        /// </summary>
+        public enum PhpSocketType
+        {
+            STREAM = SOCK_STREAM,
+            DGRAM = SOCK_DGRAM,
+            RAW = SOCK_RAW,
+            SEQPACKET = SOCK_SEQPACKET,
+            RDM = SOCK_RDM,
+        }
+
+        #endregion
+
+        //socket_accept — Accepts a connection on a socket
+
+        //socket_addrinfo_bind — Create and bind to a socket from a given addrinfo
+        //socket_addrinfo_connect — Create and connect to a socket from a given addrinfo
+        //socket_addrinfo_explain — Get information about addrinfo
+        //socket_addrinfo_lookup — Get array with contents of getaddrinfo about the given hostname
+        //socket_bind — Binds a name to a socket
+        //socket_clear_error — Clears the error on the socket or the last error code
+
+        /// <summary>
+        /// Closes a socket resource.
+        /// </summary>
+        public static void socket_close(PhpResource socket)
+        {
+            SocketResource.GetValid(socket)?.Dispose();
+        }
+
+        //socket_cmsg_space — Calculate message buffer size
+        //socket_connect — Initiates a connection on a socket
+        //socket_create_listen — Opens a socket on port to accept connections
+        //socket_create_pair — Creates a pair of indistinguishable sockets and stores them in an array
+
+        /// <summary>
+        /// Create a socket(endpoint for communication).
+        /// </summary>
+        /// <param name="domain"></param>
+        /// <param name="type"></param>
+        /// <param name="protocol"></param>
+        /// <returns></returns>
+        public static PhpResource socket_create(PhpAddressFamily domain, PhpSocketType type, ProtocolType protocol)
+        {
+            // TODO: validate arguments and return FALSE
+            return new SocketResource(new Socket(domain.GetAddressFamily(), type.GetSocketType(), protocol));
+        }
+
+        //socket_export_stream — Export a socket extension resource into a stream that encapsulates a socket
+        //socket_get_option — Gets socket options for the socket
+        //socket_getopt — Alias of socket_get_option
+        //socket_getpeername — Queries the remote side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type
+        //socket_getsockname — Queries the local side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type
+        //socket_import_stream — Import a stream
+        //socket_last_error — Returns the last error on the socket
+        //socket_listen — Listens for a connection on a socket
+        //socket_read — Reads a maximum of length bytes from a socket
+        //socket_recv — Receives data from a connected socket
+        //socket_recvfrom — Receives data from a socket whether or not it is connection-oriented
+        //socket_recvmsg — Read a message
+        //socket_select — Runs the select() system call on the given arrays of sockets with a specified timeout
+        //socket_send — Sends data to a connected socket
+        //socket_sendmsg — Send a message
+        //socket_sendto — Sends a message to a socket, whether it is connected or not
+        //socket_set_block — Sets blocking mode on a socket resource
+        //socket_set_nonblock — Sets nonblocking mode for file descriptor fd
+        //socket_set_option — Sets socket options for the socket
+        //socket_setopt — Alias of socket_set_option
+        //socket_shutdown — Shuts down a socket for receiving, sending, or both
+        //socket_strerror — Return a string describing a socket error
+        //socket_write — Write to a socket
+        //socket_wsaprotocol_info_export — Exports the WSAPROTOCOL_INFO Structure
+        //socket_wsaprotocol_info_import — Imports a Socket from another Process
+        //socket_wsaprotocol_info_release — Releases an exported WSAPROTOCOL_INFO Structure
+    }
+}

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -366,7 +366,7 @@ namespace Peachpie.Library.Network
         /// <summary>
         /// Gets socket options for the socket
         /// </summary>
-        public static PhpValue socket_get_option(PhpResource socket, SocketOptionLevel level, SocketOptionName option, PhpValue option_value)
+        public static PhpValue socket_get_option(PhpResource socket, SocketOptionLevel level, SocketOptionName option)
         {
             var s = SocketResource.GetValid(socket);
             if (s == null)
@@ -443,7 +443,11 @@ namespace Peachpie.Library.Network
             return false;
         }
 
-        //socket_getopt — Alias of socket_get_option
+        /// <summary>
+        /// Alias of socket_get_option.
+        /// </summary>
+        public static PhpValue socket_getopt(PhpResource socket, SocketOptionLevel level, SocketOptionName option) => socket_get_option(socket, level, option);
+
         //socket_getpeername — Queries the remote side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type
 
         /// <summary>

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -204,7 +204,41 @@ namespace Peachpie.Library.Network
         //socket_getsockname — Queries the local side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type
         //socket_import_stream — Import a stream
         //socket_last_error — Returns the last error on the socket
-        //socket_listen — Listens for a connection on a socket
+
+        /// <summary>
+        /// Listens for a connection on a socket.
+        /// </summary>
+        public static bool socket_listen(PhpResource socket, int backlog = 0)
+        {
+            var s = SocketResource.GetValid(socket);
+            if (s == null)
+            {
+                return false;
+            }
+
+            // applicable only to sockets of type SOCK_STREAM or SOCK_SEQPACKET
+            switch (s.Socket.SocketType)
+            {
+                case SocketType.Stream:
+                case SocketType.Seqpacket:
+
+                    try
+                    {
+                        s.Socket.Listen(backlog);
+                        return true;
+                    }
+                    catch (SocketException ex)
+                    {
+                        HandleException(s, ex);
+                        return false;
+                    }
+
+                default:
+                    PhpException.ArgumentValueNotSupported(nameof(SocketType), s.Socket.SocketType);
+                    return false;
+            }
+        }
+
         //socket_read — Reads a maximum of length bytes from a socket
         //socket_recv — Receives data from a connected socket
         //socket_recvfrom — Receives data from a socket whether or not it is connection-oriented

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -201,7 +201,41 @@ namespace Peachpie.Library.Network
         //socket_get_option — Gets socket options for the socket
         //socket_getopt — Alias of socket_get_option
         //socket_getpeername — Queries the remote side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type
-        //socket_getsockname — Queries the local side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type
+
+        /// <summary>
+        /// Queries the local side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type.
+        /// </summary>
+        public static bool socket_getsockname(PhpResource socket, out string addr) => socket_getsockname(socket, out addr, out _);
+
+        /// <summary>
+        /// Queries the local side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type.
+        /// </summary>
+        public static bool socket_getsockname(PhpResource socket, out string addr, out int port)
+        {
+            addr = null;
+            port = 0;
+
+            var s = SocketResource.GetValid(socket);
+            if (s == null)
+            {
+                return false;
+            }
+
+            var ep = s.Socket.LocalEndPoint;
+            if (ep is IPEndPoint ipep)
+            {
+                addr = ipep.Address.ToString();
+                port = ipep.Port;
+                return true;
+            }
+            else
+            {
+                PhpException.ArgumentValueNotSupported(nameof(AddressFamily), s.Socket.AddressFamily);
+                return false;
+            }
+        }
+
+
         //socket_import_stream — Import a stream
         //socket_last_error — Returns the last error on the socket
 

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -153,7 +153,7 @@ namespace Peachpie.Library.Network
                     return null;
 
                 default:
-                    PhpException.ArgumentValueNotSupported(nameof(s.Socket.AddressFamily), s.Socket.AddressFamily);
+                    PhpException.ArgumentValueNotSupported(nameof(AddressFamily), af);
                     return null;
             }
         }

--- a/src/Peachpie.Library.Network/Sockets.cs
+++ b/src/Peachpie.Library.Network/Sockets.cs
@@ -565,6 +565,7 @@ namespace Peachpie.Library.Network
             }
             else if (type == PHP_NORMAL_READ)
             {
+                // TODO: PHP_NORMAL_READ
                 throw new NotImplementedException();
             }
 
@@ -660,7 +661,37 @@ namespace Peachpie.Library.Network
             return errno.ToString();
         }
 
-        //socket_write — Write to a socket
+        /// <summary>
+        /// Write to a socket.
+        /// </summary>
+        [return: CastToFalse]
+        public static int socket_write(Context ctx, PhpResource socket, PhpString buffer, int length = -1)
+        {
+            var s = SocketResource.GetValid(socket);
+            if (s == null)
+            {
+                return -1; // FALSE
+            }
+
+            var bytes = buffer.ToBytes(ctx);
+            if (length < 0 || length > bytes.Length)
+            {
+                length = bytes.Length;
+            }
+
+            try
+            {
+                return s.Socket.Send(bytes, 0, length, SocketFlags.None);
+            }
+            catch (SocketException ex)
+            {
+                HandleException(ctx, s, ex);
+            }
+
+            //
+            return -1; // FALSE
+        }
+
         //socket_wsaprotocol_info_export — Exports the WSAPROTOCOL_INFO Structure
         //socket_wsaprotocol_info_import — Imports a Socket from another Process
         //socket_wsaprotocol_info_release — Releases an exported WSAPROTOCOL_INFO Structure

--- a/src/Peachpie.NET.Sdk/ComposerTask.cs
+++ b/src/Peachpie.NET.Sdk/ComposerTask.cs
@@ -272,6 +272,7 @@ namespace Peachpie.NET.Sdk.Tools
         static readonly Dictionary<string, string> s_knowndeps_to_packageid = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
         {
             {"ext-curl", "Peachpie.Library.Network"},
+            {"ext-sockets", "Peachpie.Library.Network"},
             {"ext-gettext", "Peachpie.Library"},
             {"ext-fileinfo", "Peachpie.Library"},
             {"ext-mbstring", "Peachpie.Library"},

--- a/src/Peachpie.Runtime/Resources/ErrResources.Designer.cs
+++ b/src/Peachpie.Runtime/Resources/ErrResources.Designer.cs
@@ -2331,6 +2331,15 @@ namespace Pchp.Core.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Supplied resource is not a valid &apos;stream&apos; resource.
+        /// </summary>
+        public static string invalid_socket_resource {
+            get {
+                return ResourceManager.GetString("invalid_socket_resource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Supplied resource is not a valid Socket Stream resource.
         /// </summary>
         public static string invalid_socket_stream_resource {
@@ -2844,8 +2853,7 @@ namespace Pchp.Core.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot add element to the array as the next element is already occupied
-        ///Cannot add element to the array as the next element is already occupied.
+        ///   Looks up a localized string similar to Cannot add element to the array as the next element is already occupied.
         /// </summary>
         public static string next_array_key_unavailable {
             get {

--- a/src/Peachpie.Runtime/Resources/ErrResources.resx
+++ b/src/Peachpie.Runtime/Resources/ErrResources.resx
@@ -1640,4 +1640,7 @@ Additional information:
   <data name="next_array_key_unavailable" xml:space="preserve">
     <value>Cannot add element to the array as the next element is already occupied</value>
   </data>
+  <data name="invalid_socket_resource" xml:space="preserve">
+    <value>Supplied resource is not a valid 'stream' resource</value>
+  </data>
 </root>


### PR DESCRIPTION
most of the functions and constants from `sockets` extension implemented through .NET `System.Net.Sockets.Socket`

what's missing:
- socket_recv — Receives data from a connected socket
- socket_recvfrom — Receives data from a socket whether or not it is connection-oriented
- socket_recvmsg — Read a message
- socket_send — Sends data to a connected socket
- socket_sendmsg — Send a message
- socket_sendto — Sends a message to a socket, whether it is connected or not
- socket_wsaprotocol_info_export — Exports the WSAPROTOCOL_INFO Structure
- socket_wsaprotocol_info_import — Imports a Socket from another Process
- socket_wsaprotocol_info_release — Releases an exported WSAPROTOCOL_INFO Structure
- socket_import_stream — Import a stream
- socket_export_stream — Export a socket extension resource into a stream that encapsulates a socket
- socket_create_pair — Creates a pair of indistinguishable sockets and stores them in an array
- socket_cmsg_space — Calculate message buffer size
- socket_addrinfo_bind — Create and bind to a socket from a given addrinfo
- socket_addrinfo_connect — Create and connect to a socket from a given addrinfo
- socket_addrinfo_explain — Get information about addrinfo
- socket_addrinfo_lookup — Get array with contents of getaddrinfo about the given hostname