### PR TITLE
Using a Task and TaskCompletionSource to give control to RequestContextCore

### DIFF
--- a/src/Peachpie.AspNetCore.Web/PhpHandlerMiddleware.cs
+++ b/src/Peachpie.AspNetCore.Web/PhpHandlerMiddleware.cs
@@ -89,16 +89,17 @@ namespace Peachpie.AspNetCore.Web
 
         public Task Invoke(HttpContext context)
         {
+            var taskSource = new TaskCompletionSource<object>();
             var script = RequestContextCore.ResolveScript(context.Request);
             if (script.IsValid)
             {
                 using (var phpctx = new RequestContextCore(context, _rootPath, _options.StringEncoding))
                 {
-                    OnContextCreated(phpctx);
-                    phpctx.ProcessScript(script);
+                    OnContextCreated(phpctx);                    
+                    Task.Run(() => phpctx.ProcessScript(script, taskSource)); // fire & forget
+                    return taskSource.Task; // At somepoint we need to set the taskSource result/exception
                 }
 
-                return Task.CompletedTask;
             }
             else
             {

--- a/src/Peachpie.AspNetCore.Web/PhpHandlerMiddleware.cs
+++ b/src/Peachpie.AspNetCore.Web/PhpHandlerMiddleware.cs
@@ -93,13 +93,17 @@ namespace Peachpie.AspNetCore.Web
             if (script.IsValid)
             {
                 var taskSource = new TaskCompletionSource<object>();
-                using (var phpctx = new RequestContextCore(context, _rootPath, _options.StringEncoding))
-                {
-                    OnContextCreated(phpctx);                    
-                    Task.Run(() => phpctx.ProcessScript(script, taskSource)).ConfigureAwait(false); // fire & forget
-                    return taskSource.Task; // This gets set in phpctx.ProcessScript
-                }
 
+                Task.Run(() =>
+                {
+                    using (var phpctx = new RequestContextCore(context, _rootPath, _options.StringEncoding))
+                    {
+                        OnContextCreated(phpctx);
+                        phpctx.ProcessScript(script, taskSource);
+                    }
+                }).ConfigureAwait(false);// fire & forget
+                    
+                return taskSource.Task; // This gets set in phpctx.ProcessScript
             }
             else
             {

--- a/src/Peachpie.AspNetCore.Web/PhpHandlerMiddleware.cs
+++ b/src/Peachpie.AspNetCore.Web/PhpHandlerMiddleware.cs
@@ -89,15 +89,15 @@ namespace Peachpie.AspNetCore.Web
 
         public Task Invoke(HttpContext context)
         {
-            var taskSource = new TaskCompletionSource<object>();
             var script = RequestContextCore.ResolveScript(context.Request);
             if (script.IsValid)
             {
+                var taskSource = new TaskCompletionSource<object>();
                 using (var phpctx = new RequestContextCore(context, _rootPath, _options.StringEncoding))
                 {
                     OnContextCreated(phpctx);                    
-                    Task.Run(() => phpctx.ProcessScript(script, taskSource)); // fire & forget
-                    return taskSource.Task; // At somepoint we need to set the taskSource result/exception
+                    Task.Run(() => phpctx.ProcessScript(script, taskSource)).ConfigureAwait(true); // fire & forget
+                    return taskSource.Task; // This gets set in phpctx.ProcessScript
                 }
 
             }

--- a/src/Peachpie.AspNetCore.Web/PhpHandlerMiddleware.cs
+++ b/src/Peachpie.AspNetCore.Web/PhpHandlerMiddleware.cs
@@ -96,7 +96,7 @@ namespace Peachpie.AspNetCore.Web
                 using (var phpctx = new RequestContextCore(context, _rootPath, _options.StringEncoding))
                 {
                     OnContextCreated(phpctx);                    
-                    Task.Run(() => phpctx.ProcessScript(script, taskSource)).ConfigureAwait(true); // fire & forget
+                    Task.Run(() => phpctx.ProcessScript(script, taskSource)).ConfigureAwait(false); // fire & forget
                     return taskSource.Task; // This gets set in phpctx.ProcessScript
                 }
 

--- a/src/Peachpie.AspNetCore.Web/RequestContextCore.cs
+++ b/src/Peachpie.AspNetCore.Web/RequestContextCore.cs
@@ -139,6 +139,7 @@ namespace Peachpie.AspNetCore.Web
 
             if (endRequest && _responseTask is object && !_responseTask.Task.IsCompleted)
             {
+                FinalizeBufferedOutput();
                 _ = _responseTask.TrySetResult(null); // Might be called more than once
             }
         }

--- a/src/Peachpie.AspNetCore.Web/RequestContextCore.cs
+++ b/src/Peachpie.AspNetCore.Web/RequestContextCore.cs
@@ -139,7 +139,7 @@ namespace Peachpie.AspNetCore.Web
 
             if (endRequest && ResponseTask is object)
             {
-               ResponseTask.SetResult(null);
+               ResponseTask.TrySetResult(null); // Might be called more than once
             }
         }
 

--- a/src/Peachpie.Runtime/Context.Output.cs
+++ b/src/Peachpie.Runtime/Context.Output.cs
@@ -47,7 +47,7 @@ namespace Pchp.Core
         /// Buffered output associated with the context.
         /// </summary>
         public BufferedOutput/*!*/BufferedOutput => EnsureBufferedOutput(false);    // Initialize lazily as not buffered output by default.
-        
+
         /// <remarks>Is <c>null</c> reference until it is not used for the first time.</remarks>
         BufferedOutput _bufferedOutput;
 
@@ -122,11 +122,17 @@ namespace Pchp.Core
             }
         }
 
+
+        private bool _alreadyFinalized = false;
         /// <summary>
         /// Flushes all remaining data from output buffers.
         /// </summary>
-        internal void FinalizeBufferedOutput()
+        protected void FinalizeBufferedOutput()
         {
+            if (_alreadyFinalized)
+            {
+                return;
+            }
             // flushes output, applies user defined output filter, and disables buffering:
             if (_bufferedOutput != null)
                 _bufferedOutput.FlushAll();
@@ -134,6 +140,7 @@ namespace Pchp.Core
             // redirects sinks:
             IsOutputBuffered = false;
             Output.Flush();
+            _alreadyFinalized = true;
         }
 
         #endregion


### PR DESCRIPTION
The idea behind this pr is that we pass a TaskCompletionSource to the RequestContextCore.ProcessScript method so that it can decide when to end the response. It does this by setting a private field which can be accessed by other members  (ie Flush, which is called by fastcgi_finish_request) or by calling Task.SetResult or Task.SetException. The TaskCompletionSource.Task is returned by the middleware, and the execution of RequestContextCore.ProcessScript is done in a non-awaited task. It seems to work. Its a bit PoC..are there any issues running the ProcessScript in a task? Also, should we call ConfigureAwait(false) on the Task.Run in the Invoke method of the middleware?