### PR TITLE
try-catch state machine

### DIFF
--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.Emit.cs
@@ -3577,8 +3577,9 @@ namespace Pchp.CodeAnalysis.CodeGen
 
         /// <summary>
         /// Emits .ret instruction with sequence point at closing brace.
+        /// Eventually emits branching to closing block.
         /// </summary>
-        public void EmitRet(TypeSymbol stack)
+        public void EmitRet(TypeSymbol stack, bool yielding = false)
         {
             // sequence point
             var body = AstUtils.BodySpanOrInvalid(Routine?.Syntax);
@@ -3588,9 +3589,9 @@ namespace Pchp.CodeAnalysis.CodeGen
             }
 
             //
-            if (_il.InExceptionHandler)
+            if (_il.InExceptionHandler || (ExtraFinallyBlock != null && !yielding))
             {
-                ((ExitBlock)this.Routine.ControlFlowGraph.Exit).EmitTmpRet(this, stack);
+                this.ExitBlock.EmitTmpRet(this, stack, yielding);
             }
             else
             {

--- a/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/CodeGenerator.cs
@@ -209,6 +209,40 @@ namespace Pchp.CodeAnalysis.CodeGen
         SourceGeneratorSymbol _smmethod;
 
         /// <summary>
+        /// Local variable containing the current state of state machine.
+        /// </summary>
+        internal LocalDefinition GeneratorStateLocal { get; set; }
+
+        /// <summary>
+        /// "finally" block to be branched in when returning from the routine.
+        /// This finally block is not handled by CLR as it is emitted outside the TryCatchFinally scope.
+        /// </summary>
+        internal BoundBlock ExtraFinallyBlock { get; set; }
+
+        internal enum ExtraFinallyState : int
+        {
+            /// <summary>continue to NextBlock</summary>
+            None = 0,
+            /// <summary>continue to next ExtraFinallyBlock, eventually EmitRet</summary>
+            Return = 1,
+            /// <summary>rethrow exception (<see cref="ExceptionToRethrowVariable"/>)</summary>
+            Exception = 2,
+        }
+
+        /// <summary>
+        /// Temporary variable holding state of "finally" block handling. Value of <see cref="ExtraFinallyState"/>.
+        /// Variable created once only if <see cref="ExtraFinallyBlock"/> is set.
+        /// Type: <c>System.Int32</c>
+        /// </summary>
+        internal TemporaryLocalDefinition ExtraFinallyStateVariable { get; set; }
+
+        /// <summary>
+        /// Temporary variable holding exception to be rethrown after "finally" block ends.
+        /// Type: <c>System.Exception</c>
+        /// </summary>
+        internal TemporaryLocalDefinition ExceptionToRethrowVariable { get; set; }
+
+        /// <summary>
         /// BoundBlock.Tag value indicating the block was emitted.
         /// </summary>
         readonly int _emmittedTag;
@@ -317,11 +351,6 @@ namespace Pchp.CodeAnalysis.CodeGen
         TypeSymbol _callerType;
         IPlace _callerTypePlace;
 
-        /// <summary>
-        /// Local variable containing the current state of state machine.
-        /// </summary>
-        internal LocalDefinition GeneratorStateLocal { get; set; }
-
         static TypeSymbol GetSelfType(TypeSymbol scope) => scope is SourceTraitTypeSymbol t ? t.TSelfParameter : scope;
 
         public SourceFileSymbol ContainingFile
@@ -330,6 +359,8 @@ namespace Pchp.CodeAnalysis.CodeGen
             internal set => _containingFile = value;
         }
         SourceFileSymbol _containingFile;
+
+        internal ExitBlock ExitBlock => ((ExitBlock)this.Routine.ControlFlowGraph.Exit);
 
         #endregion
 
@@ -378,6 +409,8 @@ namespace Pchp.CodeAnalysis.CodeGen
             : this(cg._il, cg._moduleBuilder, cg._diagnostics, cg._optimizations, cg._emitPdbSequencePoints, routine.ContainingType, cg.ContextPlaceOpt, cg.ThisPlaceOpt, routine, cg._localsPlaceOpt, cg.InitializedLocals)
         {
             _emmittedTag = cg._emmittedTag;
+            GeneratorStateLocal = cg.GeneratorStateLocal;
+            ExtraFinallyBlock = cg.ExtraFinallyBlock;
         }
 
         public CodeGenerator(SourceRoutineSymbol routine, ILBuilder il, PEModuleBuilder moduleBuilder, DiagnosticBag diagnostics, PhpOptimizationLevel optimizations, bool emittingPdb)

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundEdge.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundEdge.cs
@@ -205,7 +205,8 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
             // emit catch and finally blocks outside the try scope:
             if (!emitNestedScopes && EmitCatchFinallyOutsideScope)
             {
-                var continuewith = _finallyBlock ?? NextBlock;
+                var nextBlockOrExit = NextBlock?.FlowState != null ? NextBlock : cg.ExitBlock.GetReturnLabel();
+                var continuewith = _finallyBlock ?? nextBlockOrExit;
 
                 cg.Builder.EmitBranch(ILOpCode.Br, continuewith);
 
@@ -238,7 +239,7 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
                     cg.Builder.EmitIntegerSwitchJumpTable(
                         new[]
                         {
-                            new KeyValuePair<ConstantValue, object>(ConstantValue.Create((int)CodeGenerator.ExtraFinallyState.None), NextBlock),
+                            new KeyValuePair<ConstantValue, object>(ConstantValue.Create((int)CodeGenerator.ExtraFinallyState.None), nextBlockOrExit),
                             new KeyValuePair<ConstantValue, object>(ConstantValue.Create((int)CodeGenerator.ExtraFinallyState.Return), nextExtraFinallyBlock ?? cg.ExitBlock.GetReturnLabel()),
                             //new KeyValuePair<ConstantValue, object>(ConstantValue.Create((int)CodeGenerator.ExtraFinallyState.Exception), nextExtraFinallyBlock ?? cg.ExitBlock.GetRethrowLabel()),
                         },

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundEdge.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundEdge.cs
@@ -98,6 +98,13 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
 
     partial class TryCatchEdge
     {
+        /// <summary>
+        /// Whether to emit catch and finally bodies outside the TryCatchFinally scope.
+        /// This allows to branch inside catch or finally from outside,
+        /// or branch outside of try without calling finally (required for yield and return functionality).
+        /// </summary>
+        public bool EmitCatchFinallyOutsideScope { get; internal set; }
+
         internal override void Generate(CodeGenerator cg)
         {
             EmitTryStatement(cg);
@@ -119,8 +126,11 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
             // blocks so if the source contained both a catch and
             // a finally, nested scopes are emitted.
             bool emitNestedScopes = (!emitCatchesOnly &&
-                //(_catchBlocks.Length != 0) &&
-                (_finallyBlock != null));
+                //(_catchBlocks.Length != 0) && // always true; there is at least one "catch" block (ScriptDiedException)
+                (_finallyBlock != null && !EmitCatchFinallyOutsideScope));
+
+            // finally block not handled by CLR
+            var nextExtraFinallyBlock = cg.ExtraFinallyBlock;
 
             cg.Builder.OpenLocalScope(ScopeType.TryCatchFinally);
 
@@ -139,12 +149,25 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
                 // jump table for nested yield or await
                 EmitJumpTable(cg);
 
+                // remember finally block
+                if (_finallyBlock != null && EmitCatchFinallyOutsideScope)
+                {
+                    cg.ExtraFinallyBlock = _finallyBlock;
+                    cg.ExtraFinallyStateVariable ??= cg.GetTemporaryLocal(cg.CoreTypes.Int32, longlive: true, immediateReturn: false);
+                    cg.ExceptionToRethrowVariable ??= cg.GetTemporaryLocal(cg.CoreTypes.Exception, longlive: true, immediateReturn: false);
+                }
+
                 // try body
                 cg.GenerateScope(_body, (_finallyBlock ?? NextBlock).Ordinal);
 
-                if (NextBlock?.FlowState != null)
+                //
+                if (NextBlock != null && NextBlock.FlowState != null) // => next is reachable
                 {
-                    cg.Builder.EmitBranch(ILOpCode.Br, NextBlock);
+                    cg.Builder.EmitBranch(ILOpCode.Br,
+                        (_finallyBlock != null && EmitCatchFinallyOutsideScope)
+                        ? _finallyBlock // goto finally
+                        : NextBlock     // goto next
+                    );
                 }
             }
 
@@ -161,9 +184,13 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
                 {
                     EmitCatchBlock(cg, catchBlock);
                 }
+
+                // emit default catch block that continues to "finally" before rethrow;
+                // only if EmitCatchFinallyOutsideScope
+                EmitDefaultCatchBlock(cg);
             }
 
-            if (!emitCatchesOnly && _finallyBlock != null)
+            if (!emitCatchesOnly && _finallyBlock != null && !EmitCatchFinallyOutsideScope)
             {
                 cg.Builder.OpenLocalScope(ScopeType.Finally);
                 cg.GenerateScope(_finallyBlock, NextBlock.Ordinal);
@@ -174,6 +201,52 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
 
             // close the whole try statement scope
             cg.Builder.CloseLocalScope();
+
+            // emit catch and finally blocks outside the try scope:
+            if (!emitNestedScopes && EmitCatchFinallyOutsideScope)
+            {
+                var continuewith = _finallyBlock ?? NextBlock;
+
+                cg.Builder.EmitBranch(ILOpCode.Br, continuewith);
+
+                //
+                foreach (var catchBlock in _catchBlocks)
+                {
+                    cg.GenerateScope(catchBlock, NextBlock.Ordinal);
+                    cg.Builder.EmitBranch(ILOpCode.Br, continuewith);
+                }
+
+                // forget finally block
+                cg.ExtraFinallyBlock = nextExtraFinallyBlock;
+                Debug.Assert(cg.ExtraFinallyStateVariable != null);
+
+                //
+                if (_finallyBlock != null)
+                {
+                    // emit finally block
+                    cg.GenerateScope(_finallyBlock, NextBlock.Ordinal);
+
+                    // several "finally" states (cg.ExtraFinallyStateVariable):
+                    // - 0: none; continue to NextBlock
+                    // - 1: return; continue to nextExtraFinallyBlock, eventually EmitRet
+                    // - 2: exception; rethrow exception (cg.ExceptionToRethrowVariable)
+
+                    var stateloc = cg.GetTemporaryLocal(cg.ExtraFinallyStateVariable.EmitLoad(cg.Builder), immediateReturn: true);
+                    cg.Builder.EmitLocalStore(stateloc);
+                    Debug.Assert(stateloc.Type.TypeCode == Microsoft.Cci.PrimitiveTypeCode.Int32);
+                    
+                    cg.Builder.EmitIntegerSwitchJumpTable(
+                        new[]
+                        {
+                            new KeyValuePair<ConstantValue, object>(ConstantValue.Create((int)CodeGenerator.ExtraFinallyState.None), NextBlock),
+                            new KeyValuePair<ConstantValue, object>(ConstantValue.Create((int)CodeGenerator.ExtraFinallyState.Return), nextExtraFinallyBlock ?? cg.ExitBlock.GetReturnLabel()),
+                            //new KeyValuePair<ConstantValue, object>(ConstantValue.Create((int)CodeGenerator.ExtraFinallyState.Exception), nextExtraFinallyBlock ?? cg.ExitBlock.GetRethrowLabel()),
+                        },
+                        nextExtraFinallyBlock ?? cg.ExitBlock.GetRethrowLabel(), // ExtraFinallyState.Exception
+                        stateloc,
+                        Microsoft.Cci.PrimitiveTypeCode.Int32);
+                }
+            }
         }
 
         void EmitScriptDiedBlock(CodeGenerator cg)
@@ -186,6 +259,39 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
 
             il.OpenLocalScope(ScopeType.Catch, cg.CoreTypes.ScriptDiedException.Symbol);
             il.EmitThrow(true);
+            il.CloseLocalScope();
+        }
+
+        void EmitDefaultCatchBlock(CodeGenerator cg)
+        {
+            if (!EmitCatchFinallyOutsideScope || _finallyBlock == null)
+            {
+                return;
+            }
+
+            // emit default catch block that continues to "finally" before rethrow;
+            
+            var il = cg.Builder;
+
+            // Template: 
+            // catch (Exception ex) {
+            //   ExceptionToRethrow = ex;
+            //   ExtraFinallyState = 2;
+            //   goto _finally;
+            // }
+
+            il.OpenLocalScope(ScopeType.Catch, cg.CoreTypes.Exception.Symbol);
+
+            // ExceptionToRethrow = ex;
+            cg.ExceptionToRethrowVariable.EmitStore();
+
+            // ExtraFinallyState = 2;
+            il.EmitIntConstant((int)CodeGenerator.ExtraFinallyState.Exception); // rethrow state
+            cg.ExtraFinallyStateVariable.EmitStore();
+
+            // goto _finally;
+            il.EmitBranch(ILOpCode.Br, _finallyBlock);
+
             il.CloseLocalScope();
         }
 
@@ -300,24 +406,35 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
             }
 
             // STACK : extype
+            if (catchBlock.Variable != null)
+            {
+                cg.EmitSequencePoint(catchBlock.Variable.PhpSyntax);
 
-            // <tmp> = <ex>
-            cg.EmitSequencePoint(catchBlock.Variable.PhpSyntax);
-            var tmploc = cg.GetTemporaryLocal(extype);
-            il.EmitLocalStore(tmploc);
+                // <tmp> = <ex>
+                var tmploc = cg.GetTemporaryLocal(extype);
+                il.EmitLocalStore(tmploc);
 
-            var varplace = catchBlock.Variable.BindPlace(cg);
-            Debug.Assert(varplace != null);
-
-            // $x = <tmp>
-            varplace.EmitStore(cg, tmploc, catchBlock.Variable.TargetAccess());
+                // $x = <tmp>
+                var varplace = catchBlock.Variable.BindPlace(cg);
+                varplace.EmitStore(cg, tmploc, catchBlock.Variable.TargetAccess());
+                cg.ReturnTemporaryLocal(tmploc);
+            }
+            else
+            {
+                il.EmitOpCode(ILOpCode.Pop);
+            }
 
             //
-            cg.ReturnTemporaryLocal(tmploc);
-            tmploc = null;
-
-            //
-            cg.GenerateScope(catchBlock, NextBlock.Ordinal);
+            if (EmitCatchFinallyOutsideScope)
+            {
+                // .br
+                cg.Builder.EmitBranch(ILOpCode.Br, catchBlock);
+            }
+            else
+            {
+                // { .. }
+                cg.GenerateScope(catchBlock, NextBlock.Ordinal);
+            }
 
             //
             il.CloseLocalScope();
@@ -333,7 +450,7 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
 
             // local <state> = g._state that is switched on (can't switch on remote field)
             Debug.Assert(cg.GeneratorStateLocal != null);
-            
+
             // create label for situation when state doesn't correspond to continuation: 0 -> didn't run to first yield
             var noContinuationLabel = new NamedLabel("noStateContinuation");
 

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundStatement.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundStatement.cs
@@ -73,7 +73,7 @@ namespace Pchp.CodeAnalysis.Semantics
                 // g._state = -2 (closed): go to the end of the generator method
                 ((Graph.ExitBlock)cg.Routine.ControlFlowGraph.Exit).EmitGeneratorEnd(cg);
 
-                // .ret
+                // .ret, processes eventual finally blocks
                 cg.EmitRet(cg.CoreTypes.Void);
                 return;
             }
@@ -340,7 +340,7 @@ namespace Pchp.CodeAnalysis.Semantics
             cg.EmitCall(ILOpCode.Call, cg.CoreMethods.Operators.SetGeneratorState_Generator_int);
 
             // return & set continuation point just after that
-            cg.EmitRet(cg.CoreTypes.Void); // il.EmitRet(true);
+            cg.EmitRet(cg.CoreTypes.Void, yielding: true); // il.EmitRet(true);
             il.MarkLabel(this);
 
             // Operators.HandleGeneratorException(generator)

--- a/src/Peachpie.CodeAnalysis/Semantics/Graph/BoundBlock.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Graph/BoundBlock.cs
@@ -248,7 +248,7 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
     /// <summary>
     /// Represents control flow block of catch item.
     /// </summary>
-    [DebuggerDisplay("CatchBlock({ClassName.QualifiedName})")]
+    [DebuggerDisplay("CatchBlock({TypeRef})")]
     public partial class CatchBlock : BoundBlock //, ICatch
     {
         /// <summary>

--- a/src/Peachpie.CodeAnalysis/Semantics/Graph/BuilderVisitor.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Graph/BuilderVisitor.cs
@@ -25,6 +25,9 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
         private Stack<LocalScopeInfo> _scopes = new Stack<LocalScopeInfo>(1);
         private int _index = 0;
 
+        /// <summary>Counts visited "return" statements.</summary>
+        private int _returnCounter = 0;
+
         /// <summary>
         /// Gets enumeration of unconditional declarations.
         /// </summary>
@@ -51,20 +54,26 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
 
         #region LocalScope
 
+        private enum LocalScope
+        {
+            Code, Try, Catch, Finally,
+        }
+
         private class LocalScopeInfo
         {
-            public BoundBlock FirstBlock => _firstblock;
-            private BoundBlock _firstblock;
+            public BoundBlock FirstBlock { get; }
+            public LocalScope Scope { get; }
 
-            public LocalScopeInfo(BoundBlock firstBlock)
+            public LocalScopeInfo(BoundBlock firstBlock, LocalScope scope)
             {
-                _firstblock = firstBlock;
+                this.FirstBlock = firstBlock;
+                this.Scope = scope;
             }
         }
 
-        private void OpenScope(BoundBlock block)
+        private void OpenScope(BoundBlock block, LocalScope scope = LocalScope.Code)
         {
-            _scopes.Push(new LocalScopeInfo(block));
+            _scopes.Push(new LocalScopeInfo(block, scope));
         }
 
         private void CloseScope()
@@ -338,9 +347,9 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
             return block;
         }
 
-        private T WithOpenScope<T>(T block) where T : BoundBlock
+        private T WithOpenScope<T>(T block, LocalScope scope = LocalScope.Code) where T : BoundBlock
         {
-            OpenScope(block);
+            OpenScope(block, scope);
             return block;
         }
 
@@ -700,9 +709,11 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
 
         public override void VisitJumpStmt(JumpStmt x)
         {
-
             if (x.Type == JumpStmt.Types.Return)
             {
+                _returnCounter++;
+
+                //
                 Add(x);
                 Connect(_current, this.Exit);
             }
@@ -907,31 +918,48 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
             // TryCatchEdge // Connects _current to body, catch blocks and finally
             var edge = new TryCatchEdge(_current, body, catchBlocks, finallyBlock, end);
 
+            var oldstates0 = _binder.StatesCount;
+
             // build try body
             OpenTryScope(edge);
-            OpenScope(body);
+            OpenScope(body, LocalScope.Try);
             _current = WithNewOrdinal(body);
             VisitElement(x.Body);
             CloseScope();
             CloseTryScope();
             _current = Leave(_current, finallyBlock ?? end);
 
+            var oldstates1 = _binder.StatesCount;
+
             // built catches
             for (int i = 0; i < catchBlocks.Length; i++)
             {
-                _current = WithOpenScope(WithNewOrdinal(catchBlocks[i]));
+                _current = WithOpenScope(WithNewOrdinal(catchBlocks[i]), LocalScope.Catch);
                 VisitElement(x.Catches[i].Body);
                 CloseScope();
                 _current = Leave(_current, finallyBlock ?? end);
             }
 
             // build finally
+            var oldReturnCount = _returnCounter;
             if (finallyBlock != null)
             {
-                _current = WithOpenScope(WithNewOrdinal(finallyBlock));
+                _current = WithOpenScope(WithNewOrdinal(finallyBlock), LocalScope.Finally);
                 VisitElement(x.FinallyItem.Body);
                 CloseScope();
                 _current = Leave(_current, end);
+            }
+
+            //
+            if ((oldstates0 != oldstates1 && finallyBlock != null) ||   // yield in "try" with "finally" block
+                oldstates1 != _binder.StatesCount ||                    // yield in "catch" or "finally"
+                oldReturnCount != _returnCounter)                       // return in "finally"
+            {
+                // catch or finally introduces new states to the state machine
+                // or there is "return" in finally block:
+
+                // catch/finally must not be handled by CLR
+                edge.EmitCatchFinallyOutsideScope = true;
             }
 
             // _current == end

--- a/src/Peachpie.CodeAnalysis/Semantics/Graph/Edge.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Graph/Edge.cs
@@ -294,7 +294,11 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
             }
             else
             {
-                return new TryCatchEdge(body, catchBlocks, finallyBlock, endBlock);
+                return new TryCatchEdge(body, catchBlocks, finallyBlock, endBlock)
+                {
+                    EmitCatchFinallyOutsideScope = this.EmitCatchFinallyOutsideScope,
+
+                };
             }
         }
 

--- a/src/Peachpie.CodeAnalysis/Semantics/SemanticsBinder.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/SemanticsBinder.cs
@@ -112,6 +112,11 @@ namespace Pchp.CodeAnalysis.Semantics
         public virtual ImmutableArray<BoundYieldStatement> Yields { get => ImmutableArray<BoundYieldStatement>.Empty; }
 
         /// <summary>
+        /// Generated state machine states.
+        /// </summary>
+        public virtual int StatesCount => 0;
+
+        /// <summary>
         /// Bag with semantic diagnostics.
         /// </summary>
         public DiagnosticBag Diagnostics => DeclaringCompilation.DeclarationDiagnostics;
@@ -1282,6 +1287,9 @@ namespace Pchp.CodeAnalysis.Semantics
         /// Found yield statements (needed for ControlFlowGraph)
         /// </summary>
         public override ImmutableArray<BoundYieldStatement> Yields { get => _yields.ToImmutableArray(); }
+
+        public override int StatesCount => _yields.Count;
+
         readonly List<BoundYieldStatement> _yields = new List<BoundYieldStatement>();
 
         readonly HashSet<AST.LangElement> _yieldsToStatementRootPath = new HashSet<AST.LangElement>();

--- a/tests/functions/return_finally.php
+++ b/tests/functions/return_finally.php
@@ -1,0 +1,44 @@
+<?php
+namespace functions\return_finally;
+
+// returning value from "finally"
+
+function f1()
+{
+    try
+    {
+        return 111;
+    }
+    catch (\Exception $ex)
+    {
+        return 222;
+    }
+    finally
+    {
+        return 666;
+    }
+}
+
+function f2()
+{
+    try {
+        try {
+            return 111;
+        }
+        catch (\Exception $ex) {
+            return 222;
+        }
+        finally {
+            return 666;
+        }
+    }
+    catch (\Exception $ex) {
+        return 333;
+    }
+    finally {
+        return 777;
+    }
+}
+
+echo f1();
+echo f2();

--- a/tests/generators/generators_018.php
+++ b/tests/generators/generators_018.php
@@ -1,0 +1,36 @@
+<?php
+namespace generators\generators_018;
+
+// "yield" in "catch/finally" block
+// https://github.com/peachpiecompiler/peachpie/issues/604
+
+function g($a)
+{
+    echo "Start,";
+
+    try {
+
+        yield "0,";
+
+        if ($a) throw new \Exception;
+
+    } catch (\Exception $ex) {
+
+        echo "<Catch,";
+
+        yield "1,";
+        yield "2,";
+        
+        echo "Catch>,";
+    }
+    finally {
+        echo "Finally,";
+    }
+
+    echo "End,";
+}
+
+foreach (g(true) as $x) echo $x;
+echo PHP_EOL;
+foreach (g(false) as $x) echo $x;
+echo PHP_EOL, "Done.";


### PR DESCRIPTION
closes https://github.com/peachpiecompiler/peachpie/issues/604

In case it's necessary, emits TryCatchFinally scope as a state machine, catch and finally are out of the scope, branched into from the exception handling scope. 

implemented support for `return`
- [x] in `finally` block

implemented support for `yield`
- [x] in `catch` block
- [x] in `finally` block
- [x] fixed `yield` in `try` block

- [x] finally block is branched into explicitly, not handled by CLR
- [ ] using `goto` outside `try/catch` may not invoke code in `finally`

- [x] fixes `return` from try scope (must not use `.ret` opcode)
- [x] removes diagnostics for yield and return in blocks above
- [x] tests included