### PR TITLE
Update MySqlConnector to 1.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
   <PropertyGroup>
     
     <PeachpieLibraryRegularExpressionsVersion>1.4.0</PeachpieLibraryRegularExpressionsVersion>
-    <MySqlConnectorVersion>0.69.3</MySqlConnectorVersion>
+    <MySqlConnectorVersion>1.0.0-beta.1</MySqlConnectorVersion>
     
   </PropertyGroup>
 

--- a/src/PDO/Peachpie.Library.PDO.MySQL/PDOMySQLDriver.cs
+++ b/src/PDO/Peachpie.Library.PDO.MySQL/PDOMySQLDriver.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using MySql.Data.MySqlClient;
-
+using MySqlConnector;
 using Pchp.Core;
 using Peachpie.Library.PDO.Utilities;
 

--- a/src/Peachpie.Library.MySql/Extensions.cs
+++ b/src/Peachpie.Library.MySql/Extensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Peachpie.Library.MySql
 {

--- a/src/Peachpie.Library.MySql/MySql.Functions.cs
+++ b/src/Peachpie.Library.MySql/MySql.Functions.cs
@@ -1,4 +1,4 @@
-﻿using MySql.Data.MySqlClient;
+﻿using MySqlConnector;
 using Pchp.Core;
 using System;
 using System.Collections.Generic;

--- a/src/Peachpie.Library.MySql/MySqlConnectionResource.cs
+++ b/src/Peachpie.Library.MySql/MySqlConnectionResource.cs
@@ -1,4 +1,4 @@
-﻿using MySql.Data.MySqlClient;
+﻿using MySqlConnector;
 using Pchp.Core;
 using Pchp.Library.Database;
 using System;

--- a/src/Peachpie.Library.MySql/MySqlResultResource.cs
+++ b/src/Peachpie.Library.MySql/MySqlResultResource.cs
@@ -1,5 +1,4 @@
-﻿using MySql.Data.MySqlClient;
-using MySql.Data.Types;
+﻿using MySqlConnector;
 using Pchp.Core;
 using Pchp.Library.Database;
 using System;

--- a/src/Peachpie.Library.MySql/MySqli/mysqli.cs
+++ b/src/Peachpie.Library.MySql/MySqli/mysqli.cs
@@ -4,7 +4,7 @@ using System.Data;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Pchp.Core;
 using static Peachpie.Library.MySql.MySqli.Functions;
 

--- a/src/Peachpie.Library.MySql/MySqli/mysqli_stmt.cs
+++ b/src/Peachpie.Library.MySql/MySqli/mysqli_stmt.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Text;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Pchp.Core;
 
 namespace Peachpie.Library.MySql.MySqli


### PR DESCRIPTION
MySqlConnector 1.0 changes the primary namespace to `MySqlConnector`: https://github.com/mysql-net/MySqlConnector/issues/824; this updates all relevant code.

This starts the discussion around updating MySqlConnector to 1.0, but doesn't need to be merged until it's out of beta.