### PR TITLE
Fix utf8_encode / utf8_decode

### DIFF
--- a/src/Peachpie.Library/Xml.cs
+++ b/src/Peachpie.Library/Xml.cs
@@ -537,34 +537,14 @@ namespace Pchp.Library
         /// <param name="data">An ISO-8859-1 string. </param>
         /// <returns>Returns the UTF-8 translation of data.</returns>
         //[return:CastToFalse]
-        public static string utf8_encode(string data)
+        public static PhpString utf8_encode(string data)
         {
             if (string.IsNullOrEmpty(data))
             {
                 return string.Empty;
+            } else {
+                return new PhpString(Encoding.UTF8.GetBytes(data));
             }
-
-            // this function transforms ISO-8859-1 binary string into UTF8 string
-            // since our internal representation is native CLR string - UTF16, we have changed this semantic
-
-            //string encoded;
-
-            //if (!data.ContainsBinayString)
-            //{
-            //    encoded = (string)data;
-            //}
-            //else
-            //{
-            //    // if we got binary string, assume it's ISO-8859-1 encoded string and convert it to System.String
-            //    encoded = ISO_8859_1_Encoding.GetString((data).ToBytes);
-            //}
-
-            //// return utf8 encoded data
-            //return (Configuration.Application.Globalization.PageEncoding == Encoding.UTF8) ?
-            //    (object)encoded : // PageEncoding is UTF8, we can keep .NET string, which will be converted to UTF8 byte stream as it would be needed
-            //    (object)new PhpBytes(Encoding.UTF8.GetBytes(encoded));   // conversion of string to byte[] would not respect UTF8 encoding, convert it now
-
-            return data;
         }
 
         /// <summary>
@@ -572,18 +552,10 @@ namespace Pchp.Library
         /// </summary>
         /// <param name="data">An ISO-8859-1 string. </param>
         /// <returns>Returns the UTF-8 translation of data.</returns>
-        public static PhpString utf8_decode(string data)
+        public static string utf8_decode(PhpString data)
         {
-            if (data == null)
-            {
-                return new PhpString();  // empty (binary) string
-            }
-
-            // this function converts the UTF8 representation to ISO-8859-1 representation
-            // we assume CLR string (UTF16) as input as it is our internal representation
-
-            // if we got System.String string, convert it from UTF16 CLR representation into ISO-8859-1 binary representation
-            return new PhpString(ISO_8859_1_Encoding.GetBytes(data));
+            byte[] isoBytes = data.ToBytes(ISO_8859_1_Encoding);
+            return Encoding.UTF8.GetString(isoBytes);
         }
 
         #endregion


### PR DESCRIPTION
Tested with:
```
$f = fopen("test.txt", 'w');
fwrite($f, utf8_decode(chr(195) . chr(161)));	// Should write chr(160)
fwrite($f, utf8_encode(chr(160)));	// Should write chr(195) . chr(161)
fclose($f);
```

I checked the output file with a hex-viewer and confirmed that the output is correct when written to a file, but for some reason (bug?) Peachpie fails to compare equivalent strings. 

For example, this asserts fail when they shouldn't:

```
assert(utf8_encode(chr(160)) == chr(195) . chr(161));
assert(utf8_decode(chr(195) . chr(161)) == chr(160));
```

I noticed similar problems related with string comparison in the past, and making some tests I found a bug that could be related:
https://github.com/peachpiecompiler/peachpie/issues/775

Please take a look why this asserts fail.