### PR TITLE
Make the PHP scripts appear in Visual Studio's Solution Explorer

### DIFF
--- a/src/Tests/Peachpie.ScriptTests/Peachpie.ScriptTests.csproj
+++ b/src/Tests/Peachpie.ScriptTests/Peachpie.ScriptTests.csproj
@@ -27,6 +27,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Make the PHP scripts appear in Visual Studio's Solution Explorer -->
+    <None Include="..\..\..\tests\**">
+      <Link>Scripts\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 

--- a/src/Tests/Peachpie.ScriptTests/Peachpie.ScriptTests.csproj
+++ b/src/Tests/Peachpie.ScriptTests/Peachpie.ScriptTests.csproj
@@ -28,8 +28,8 @@
 
   <ItemGroup>
     <!-- Make the PHP scripts appear in Visual Studio's Solution Explorer -->
-    <None Include="..\..\..\tests\**">
-      <Link>Scripts\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    <None Include="$(MSBuildThisFileDirectory)..\..\..\tests\**\*.php">
+      <Link>tests\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
This is simple QoL improvements to be able to see the PHP test files from within the VS Solution Explorer:
![image](https://user-images.githubusercontent.com/7137528/91659440-cc017980-eacf-11ea-91d8-6b4f79e3db54.png)
