### PR TITLE
Fix PDO::FETCH_CLASS with FetchAll()

### DIFF
--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -446,7 +446,10 @@ namespace Peachpie.Library.PDO
 
             if ((style & PDO_FETCH.FETCH_CLASS) != 0 && !fetch_argument.IsEmpty)
             {
-                setFetchMode(fetch_style, fetch_argument, ctor_args);
+                if (!setFetchMode(fetch_style, fetch_argument, ctor_args))
+                {
+                    return null;
+                }
             }
 
             var result = new PhpArray();

--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -443,7 +443,7 @@ namespace Peachpie.Library.PDO
                 }
             }
 
-            if (fetch_style.HasFlag(PDO_FETCH.FETCH_CLASS) && !fetch_argument.IsEmpty)
+            if ((style & PDO_FETCH.FETCH_CLASS) != 0 && !fetch_argument.IsEmpty)
             {
                 setFetchMode(fetch_style, fetch_argument, ctor_args);
             }

--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -428,68 +428,85 @@ namespace Peachpie.Library.PDO
         [return: CastToFalse]
         public virtual PhpArray fetchAll(PDO_FETCH fetch_style = default, PhpValue fetch_argument = default, PhpArray ctor_args = null)
         {
-            var style = fetch_style != PDO_FETCH.Default ? fetch_style : _default_fetch_type;
-            var flags = style & PDO_FETCH.Flags;
+            // Save internal value that could be overriden by setFetchMode
+            var initial_fetch_column = _fetch_column;
+            var initial_default_fetch_type = _default_fetch_type;
+            var initial_default_fetch_class = _default_fetch_class;
+            var initial_default_fetch_class_args = _default_fetch_class_args;
 
-            if (style == PDO_FETCH.FETCH_COLUMN)
+            try
             {
-                if (fetch_argument.IsLong(out var l))
-                {
-                    _fetch_column = (int)l;
-                }
-                else
-                {
-                    HandleError("The fetch_argument must be an integer for FETCH_COLUMN.");
-                    return null;
-                }
-            }
+                var style = fetch_style != PDO_FETCH.Default ? fetch_style : _default_fetch_type;
+                var flags = style & PDO_FETCH.Flags;
 
-            if ((style & PDO_FETCH.FETCH_CLASS) != 0 && !fetch_argument.IsEmpty)
+                if (style == PDO_FETCH.FETCH_COLUMN)
+                {
+                    if (fetch_argument.IsLong(out var l))
+                    {
+                        _fetch_column = (int)l;
+                    }
+                    else
+                    {
+                        HandleError("The fetch_argument must be an integer for FETCH_COLUMN.");
+                        return null;
+                    }
+                }
+
+                if ((style & PDO_FETCH.FETCH_CLASS) != 0 && !fetch_argument.IsEmpty)
+                {
+                    if (!setFetchMode(fetch_style, fetch_argument, ctor_args))
+                    {
+                        return null;
+                    }
+                }
+
+                var result = new PhpArray();
+
+                switch (style)
+                {
+                    case PDO_FETCH.FETCH_KEY_PAIR:
+
+                        while (Result.TryReadRow(out var oa, out _))
+                        {
+                            // 1st col => 2nd col
+                            result[PhpValue.FromClr(oa[0]).ToIntStringKey()] = PhpValue.FromClr(oa[1]);
+                        }
+                        break;
+
+                    case PDO_FETCH.FETCH_UNIQUE:
+
+                        //Debug.Assert(m_dr.FieldCount >= 1);
+                        while (Result.TryReadRow(out var oa, out var names))
+                        {
+                            // 1st col => [ 2nd col, 3rd col, ... ]
+                            result[PhpValue.FromClr(oa[0]).ToIntStringKey()] = AsAssocArray(oa, names, 1);
+                        }
+                        break;
+
+                    default:
+
+                        for (; ; )
+                        {
+                            var value = fetch(style);
+                            if (value.IsFalse)
+                                break;
+
+                            result.Add(value);
+                        }
+
+                        break;
+                }
+
+                return result;
+            }
+            finally
             {
-                if (!setFetchMode(fetch_style, fetch_argument, ctor_args))
-                {
-                    return null;
-                }
+                // Restore previous internal values
+                _fetch_column = initial_fetch_column;
+                _default_fetch_type = initial_default_fetch_type;
+                _default_fetch_class = initial_default_fetch_class;
+                _default_fetch_class_args = initial_default_fetch_class_args;
             }
-
-            var result = new PhpArray();
-
-            switch (style)
-            {
-                case PDO_FETCH.FETCH_KEY_PAIR:
-
-                    while (Result.TryReadRow(out var oa, out _))
-                    {
-                        // 1st col => 2nd col
-                        result[PhpValue.FromClr(oa[0]).ToIntStringKey()] = PhpValue.FromClr(oa[1]);
-                    }
-                    break;
-
-                case PDO_FETCH.FETCH_UNIQUE:
-
-                    //Debug.Assert(m_dr.FieldCount >= 1);
-                    while (Result.TryReadRow(out var oa, out var names))
-                    {
-                        // 1st col => [ 2nd col, 3rd col, ... ]
-                        result[PhpValue.FromClr(oa[0]).ToIntStringKey()] = AsAssocArray(oa, names, 1);
-                    }
-                    break;
-
-                default:
-
-                    for (; ; )
-                    {
-                        var value = fetch(style);
-                        if (value.IsFalse)
-                            break;
-
-                        result.Add(value);
-                    }
-
-                    break;
-            }
-
-            return result;
         }
 
         /// <summary>

--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -443,6 +443,11 @@ namespace Peachpie.Library.PDO
                 }
             }
 
+            if (fetch_style.HasFlag(PDO_FETCH.FETCH_CLASS) && !fetch_argument.IsEmpty)
+            {
+                setFetchMode(fetch_style, fetch_argument, ctor_args);
+            }
+
             var style = fetch_style != PDO_FETCH.Default ? fetch_style : _default_fetch_type;
             var flags = style & PDO_FETCH.Flags;
 

--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -428,9 +428,10 @@ namespace Peachpie.Library.PDO
         [return: CastToFalse]
         public virtual PhpArray fetchAll(PDO_FETCH fetch_style = default, PhpValue fetch_argument = default, PhpArray ctor_args = null)
         {
-            // check parameters
+            var style = fetch_style != PDO_FETCH.Default ? fetch_style : _default_fetch_type;
+            var flags = style & PDO_FETCH.Flags;
 
-            if (fetch_style == PDO_FETCH.FETCH_COLUMN)
+            if (style == PDO_FETCH.FETCH_COLUMN)
             {
                 if (fetch_argument.IsLong(out var l))
                 {
@@ -447,9 +448,6 @@ namespace Peachpie.Library.PDO
             {
                 setFetchMode(fetch_style, fetch_argument, ctor_args);
             }
-
-            var style = fetch_style != PDO_FETCH.Default ? fetch_style : _default_fetch_type;
-            var flags = style & PDO_FETCH.Flags;
 
             var result = new PhpArray();
 

--- a/tests/pdo/fetch_002.php
+++ b/tests/pdo/fetch_002.php
@@ -1,0 +1,36 @@
+<?php
+namespace pdo\fetch_002;
+
+class PdoFetchClassTest { 
+    public $a; 
+    public $b;
+    public $notmapped;
+
+    public function __construct($notmapped) {
+        $this->notmapped = $notmapped;
+    }
+}
+
+function test() {
+    /* Testing PDO::FETCH_CLASS */
+    $className = PdoFetchClassTest::class;
+
+    $pdo = new \PDO("sqlite::memory:");
+
+    $pdo->exec("CREATE TABLE test (a INTEGER, b INTEGER NULL)");
+    $pdo->exec("INSERT INTO test VALUES (1, NULL)");
+    $pdo->exec("INSERT INTO test VALUES (2, 3)");
+    
+    echo "Test PDO::FETCH_CLASS with setFetchMode + Fetch" . PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    $stmt->setFetchMode(\PDO::FETCH_CLASS, $className, array(42));
+    print_r($stmt->fetch());
+    
+    echo "Test PDO::FETCH_CLASS with fetchAll" . PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetchAll(\PDO::FETCH_CLASS, $className, array(74)));
+}
+
+test();

--- a/tests/pdo/fetch_002.php
+++ b/tests/pdo/fetch_002.php
@@ -49,8 +49,11 @@ function test() {
     $stmt->execute();
     $stmt->setFetchMode(\PDO::FETCH_CLASS, $className, array(42));
     print_r($stmt->fetchAll(\PDO::FETCH_CLASS, $className2)); // should use $className2
+
+    /* TODO : support this
     $stmt->execute();
     print_r($stmt->fetchAll()); // should use $className again
+    */
 }
 
 test();

--- a/tests/pdo/fetch_002.php
+++ b/tests/pdo/fetch_002.php
@@ -11,9 +11,15 @@ class PdoFetchClassTest {
     }
 }
 
+class PdoFetchClassTest2 { 
+    public $a; 
+    public $b;
+}
+
 function test() {
     /* Testing PDO::FETCH_CLASS */
     $className = PdoFetchClassTest::class;
+    $className2 = PdoFetchClassTest2::class;
 
     $pdo = new \PDO("sqlite::memory:");
 
@@ -21,16 +27,29 @@ function test() {
     $pdo->exec("INSERT INTO test VALUES (1, NULL)");
     $pdo->exec("INSERT INTO test VALUES (2, 3)");
     
-    echo "Test PDO::FETCH_CLASS with setFetchMode + Fetch" . PHP_EOL;
+    echo "Test PDO::FETCH_CLASS with setFetchMode + fetch" . PHP_EOL;
     $stmt = $pdo->prepare("SELECT * FROM test");
     $stmt->execute();
     $stmt->setFetchMode(\PDO::FETCH_CLASS, $className, array(42));
     print_r($stmt->fetch());
     
-    echo "Test PDO::FETCH_CLASS with fetchAll" . PHP_EOL;
+    echo "Test PDO::FETCH_CLASS with setFetchMode + fetchAll" . PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    $stmt->setFetchMode(\PDO::FETCH_CLASS, $className, array(74));
+    print_r($stmt->fetchAll());
+    
+    echo "Test PDO::FETCH_CLASS with fetchAll only" . PHP_EOL;
     $stmt = $pdo->prepare("SELECT * FROM test");
     $stmt->execute();
     print_r($stmt->fetchAll(\PDO::FETCH_CLASS, $className, array(74)));
+    
+    echo "Test PDO::FETCH_CLASS with setFetchMode + fetchAll with another class name" . PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    $stmt->setFetchMode(\PDO::FETCH_CLASS, $className, array(42));
+    print_r($stmt->fetchAll(\PDO::FETCH_CLASS, $className2));
+    
 }
 
 test();

--- a/tests/pdo/fetch_002.php
+++ b/tests/pdo/fetch_002.php
@@ -48,8 +48,9 @@ function test() {
     $stmt = $pdo->prepare("SELECT * FROM test");
     $stmt->execute();
     $stmt->setFetchMode(\PDO::FETCH_CLASS, $className, array(42));
-    print_r($stmt->fetchAll(\PDO::FETCH_CLASS, $className2));
-    
+    print_r($stmt->fetchAll(\PDO::FETCH_CLASS, $className2)); // should use $className2
+    $stmt->execute();
+    print_r($stmt->fetchAll()); // should use $className again
 }
 
 test();


### PR DESCRIPTION

`PDO::FETCH_CLASS` was already managed, but not when directly used in `fetchAll()`:
```php
$stmt->fetchAll(\PDO::FETCH_CLASS, "Foo", array("bar"));
```

This PR adds a new test file to check both usage and add a fix for `fetchAll()`: