### PR TITLE
Fix key ordering when fetching using both numeric and associative keys

### DIFF
--- a/src/Peachpie.Library/Database/ResultResource.cs
+++ b/src/Peachpie.Library/Database/ResultResource.cs
@@ -362,8 +362,8 @@ namespace Pchp.Library.Database
                 {
                     var quoted = PhpValue.FromClr(oa[i]); //  Core.Utilities.StringUtils.AddDbSlashes(oa[i].ToString());
 
-                    if (intKeys) array[i] = quoted;
                     if (stringKeys) array[names[i]] = quoted;
+                    if (intKeys) array[i] = quoted;
                 }
 
                 return array;

--- a/tests/pdo/fetch_001.php
+++ b/tests/pdo/fetch_001.php
@@ -16,13 +16,47 @@ function test() {
 
     $pdo->exec("CREATE TABLE test (n INTEGER NULL, i INTEGER, r REAL, t TEXT, b BLOB)");
     $pdo->exec("INSERT INTO test VALUES (NULL, 42, 3.14, 'Lorem Ipsum', 'Dolor sit amet')");
-
+    $pdo->exec("INSERT INTO test VALUES (1, 74, 3.14, 'Foo', 'Bar')");
+    
+    echo "Test with fetch with assoc".PHP_EOL;
     $stmt = $pdo->prepare("SELECT * FROM test");
     $stmt->execute();
+    print_r($stmt->fetch(\PDO::FETCH_ASSOC));
 
-    foreach ($stmt->fetch(\PDO::FETCH_ASSOC) as $val) {
-        echo "{$val}:", gettype($val), PHP_EOL;
-    }
+    echo "Test with fetchAll with assoc".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetchAll(\PDO::FETCH_ASSOC));
+    
+    echo "Test with fetch with num".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetch(\PDO::FETCH_NUM));
+
+    echo "Test with fetchAll with num".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetchAll(\PDO::FETCH_NUM));
+    
+    echo "Test with fetch with both".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetch(\PDO::FETCH_BOTH));
+
+    echo "Test with fetchAll with both".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetchAll(\PDO::FETCH_BOTH));
+    
+    echo "Test with fetch with both (default)".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetch());
+
+    echo "Test with fetchAll with both (default)".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetchAll());
 }
 
 test();


### PR DESCRIPTION

Fix the order in which the keys are added to the array to match PHP implementation.