### PR TITLE
Implements FETCH_GROUP

### DIFF
--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -470,6 +470,7 @@ namespace Peachpie.Library.PDO
                     break;
 
                 default:
+                    var hasGroupFlag = (style & PDO_FETCH.FETCH_GROUP) != 0;
 
                     for (; ; )
                     {
@@ -477,7 +478,22 @@ namespace Peachpie.Library.PDO
                         if (value.IsFalse)
                             break;
 
-                        result.Add(value);
+                        // Handle FETCH_GROUP case 
+                        if (hasGroupFlag)
+                        {
+                            var row = value.ToArray();
+
+                            // We remove the first column and use it to group rows
+                            var firstCol = row.RemoveFirst().Value;
+
+                            if (!result.ContainsKey(firstCol))
+                                result.Add(firstCol, new PhpArray());
+
+                            result[firstCol].ToArray().Add(row);
+                        } else
+                        {
+                            result.Add(value);
+                        }
                     }
 
                     break;

--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -485,6 +485,7 @@ namespace Peachpie.Library.PDO
 
                             // We remove the first column and use it to group rows
                             var firstCol = row.RemoveFirst().Value;
+                            row.ReindexIntegers(0);
 
                             if (!result.ContainsKey(firstCol))
                                 result.Add(firstCol, new PhpArray());

--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -470,9 +470,6 @@ namespace Peachpie.Library.PDO
                     break;
 
                 default:
-                    var hasGroupFlag = (style & PDO_FETCH.FETCH_GROUP) != 0;
-                    var hasBothFlag = (style & PDO_FETCH.FETCH_BOTH) != 0
-                            || (style & ~PDO_FETCH.Flags) == PDO_FETCH.Default;
 
                     for (; ; )
                     {
@@ -480,36 +477,48 @@ namespace Peachpie.Library.PDO
                         if (value.IsFalse)
                             break;
 
-                        // Handle FETCH_GROUP case 
-                        if (hasGroupFlag)
-                        {
-                            var row = value.ToArray();
-
-                            // We remove the first column and use it to group rows
-                            var firstCol = row.RemoveFirst().Value;
-
-                            // When values are set twice, we need to remove the numeric one which remains
-                            if (hasBothFlag)
-                            {
-                                row.RemoveKey((IntStringKey)0);
-                            }
-
-                            row.ReindexIntegers(0);
-
-                            if (!result.ContainsKey(firstCol))
-                                result.Add(firstCol, new PhpArray());
-
-                            result[firstCol].ToArray().Add(row);
-                        } else
-                        {
-                            result.Add(value);
-                        }
+                        result.Add(value);
                     }
 
                     break;
             }
 
-            return result;
+
+            // Handle FETCH_GROUP case 
+            if (flags == PDO_FETCH.FETCH_GROUP && !result.IsEmpty())
+            {
+                // hasNumKeys: when FETCH_NUM or FETCH_BOTH
+                var hasNumKeys = result[0].ToArray().ContainsKey((IntStringKey)0);
+
+                var groupedResult = new PhpArray();
+                foreach (var kp in result)
+                {
+                    var row = kp.Value.ToArray();
+
+                    // We remove the first column and use it to group rows
+                    var firstCol = row.RemoveFirst().Value;
+
+                    // For numeric keys
+                    // => Always remove the 0 key (FETCH_NUM: does nothing, FETCH_BOTH: remove remaining)
+                    // => Reindex starting from 0
+                    if (hasNumKeys)
+                    {
+                        row.RemoveKey((IntStringKey)0);
+                        row.ReindexIntegers(0);
+                    }
+
+                    if (!groupedResult.ContainsKey(firstCol))
+                        groupedResult.Add(firstCol, new PhpArray());
+
+                    groupedResult[firstCol].ToArray().Add(row);
+                }
+
+                return groupedResult;
+            } else
+            {
+                return result;
+            }
+
         }
 
         /// <summary>

--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -505,9 +505,11 @@ namespace Peachpie.Library.PDO
             }
 
             // hasNumKeys: when FETCH_NUM or FETCH_BOTH
+            var fetch = style & ~PDO_FETCH.Flags;
             var hasNumKeys =
-                (style & ~PDO_FETCH.Flags) == PDO_FETCH.FETCH_NUM ||
-                (style & ~PDO_FETCH.Flags) == PDO_FETCH.FETCH_BOTH;
+                fetch == PDO_FETCH.FETCH_NUM ||
+                fetch == PDO_FETCH.FETCH_BOTH ||
+                fetch == PDO_FETCH.Default; // == FETCH_BOTH
 
             var grouped_result = new PhpArray();
             var resultenum = result.GetFastEnumerator();

--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -485,40 +485,63 @@ namespace Peachpie.Library.PDO
 
 
             // Handle FETCH_GROUP case 
-            if (flags == PDO_FETCH.FETCH_GROUP && !result.IsEmpty())
+            if (flags == PDO_FETCH.FETCH_GROUP)
             {
-                // hasNumKeys: when FETCH_NUM or FETCH_BOTH
-                var hasNumKeys = result[0].ToArray().ContainsKey((IntStringKey)0);
+                result = GroupResult(result, style);
+            }
 
-                var groupedResult = new PhpArray();
-                foreach (var kp in result)
-                {
-                    var row = kp.Value.ToArray();
+            //
+            return result;
+        }
 
-                    // We remove the first column and use it to group rows
-                    var firstCol = row.RemoveFirst().Value;
-
-                    // For numeric keys
-                    // => Always remove the 0 key (FETCH_NUM: does nothing, FETCH_BOTH: remove remaining)
-                    // => Reindex starting from 0
-                    if (hasNumKeys)
-                    {
-                        row.RemoveKey((IntStringKey)0);
-                        row.ReindexIntegers(0);
-                    }
-
-                    if (!groupedResult.ContainsKey(firstCol))
-                        groupedResult.Add(firstCol, new PhpArray());
-
-                    groupedResult[firstCol].ToArray().Add(row);
-                }
-
-                return groupedResult;
-            } else
+        /// <summary>
+        /// Create result set grouped by the forst column according to <see cref="PDO.FETCH_GROUP"/>.
+        /// </summary>
+        private protected static PhpArray/*!!*/GroupResult(PhpArray result, PDO_FETCH style)
+        {
+            if (result.IsEmpty())
             {
                 return result;
             }
 
+            // hasNumKeys: when FETCH_NUM or FETCH_BOTH
+            var hasNumKeys =
+                (style & ~PDO_FETCH.Flags) == PDO_FETCH.FETCH_NUM ||
+                (style & ~PDO_FETCH.Flags) == PDO_FETCH.FETCH_BOTH;
+
+            var grouped_result = new PhpArray();
+            var resultenum = result.GetFastEnumerator();
+            while (resultenum.MoveNext())
+            {
+                var row = resultenum.CurrentValue.AsArray();
+                if (row == null) throw new InvalidOperationException(); // row is expected to be array, check flags before grouping results
+
+                // We remove the first column and use it to group rows
+                var firstCol = row.RemoveFirst().Value;
+
+                // For numeric keys
+                // => Always remove the 0 key (FETCH_NUM: does nothing, FETCH_BOTH: remove remaining)
+                // => Reindex starting from 0
+                if (hasNumKeys && row.Remove(0))
+                {
+                    row.ReindexIntegers(0);
+                }
+
+                PhpArray group;
+                if (grouped_result.TryGetValue(firstCol, out var existing))
+                {
+                    group = (PhpArray)existing.Object;
+                }
+                else
+                {
+                    grouped_result.Add(firstCol, group = new PhpArray());
+                }
+
+                group.Add(row);
+            }
+
+            //
+            return grouped_result;
         }
 
         /// <summary>

--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -471,6 +471,8 @@ namespace Peachpie.Library.PDO
 
                 default:
                     var hasGroupFlag = (style & PDO_FETCH.FETCH_GROUP) != 0;
+                    var hasBothFlag = (style & PDO_FETCH.FETCH_BOTH) != 0
+                            || (style & ~PDO_FETCH.Flags) == PDO_FETCH.Default;
 
                     for (; ; )
                     {
@@ -485,6 +487,13 @@ namespace Peachpie.Library.PDO
 
                             // We remove the first column and use it to group rows
                             var firstCol = row.RemoveFirst().Value;
+
+                            // When values are set twice, we need to remove the numeric one which remains
+                            if (hasBothFlag)
+                            {
+                                row.RemoveKey((IntStringKey)0);
+                            }
+
                             row.ReindexIntegers(0);
 
                             if (!result.ContainsKey(firstCol))

--- a/tests/pdo/fetch_003.php
+++ b/tests/pdo/fetch_003.php
@@ -19,6 +19,16 @@ function test() {
     $stmt = $pdo->prepare("SELECT * FROM test");
     $stmt->execute();
     print_r($stmt->fetchAll(\PDO::FETCH_ASSOC | \PDO::FETCH_GROUP));
+    
+    echo "Test with Fetch with num&group".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetch(\PDO::FETCH_NUM | \PDO::FETCH_GROUP));
+    
+    echo "Test with FetchAll with num&group".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetchAll(\PDO::FETCH_NUM | \PDO::FETCH_GROUP));
 }
 
 test();

--- a/tests/pdo/fetch_003.php
+++ b/tests/pdo/fetch_003.php
@@ -1,0 +1,24 @@
+<?php
+namespace pdo\fetch_003;
+
+function test() {
+    /* Testing PDO::FETCH_GROUP */
+    $pdo = new \PDO("sqlite::memory:");
+
+    $pdo->exec("CREATE TABLE test (a INTEGER, n INTEGER NULL, i INTEGER, r REAL, t TEXT, b BLOB)");
+    $pdo->exec("INSERT INTO test VALUES (1, NULL, 42, 3.14, 'Lorem Ipsum', 'Dolor sit amet')");
+    $pdo->exec("INSERT INTO test VALUES (2, NULL, 42, 3.14, 'Lorem Ipsum', 'Dolor sit amet')");
+    $pdo->exec("INSERT INTO test VALUES (1, 2, 74, 3.1425, 'Foo', 'Bar')");
+    
+    echo "Test with Fetch with assoc&group".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetch(\PDO::FETCH_ASSOC | \PDO::FETCH_GROUP));
+    
+    echo "Test with FetchAll with assoc&group".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetchAll(\PDO::FETCH_ASSOC | \PDO::FETCH_GROUP));
+}
+
+test();

--- a/tests/pdo/fetch_003.php
+++ b/tests/pdo/fetch_003.php
@@ -9,26 +9,46 @@ function test() {
     $pdo->exec("INSERT INTO test VALUES (1, NULL, 42, 3.14, 'Lorem Ipsum', 'Dolor sit amet')");
     $pdo->exec("INSERT INTO test VALUES (2, NULL, 42, 3.14, 'Lorem Ipsum', 'Dolor sit amet')");
     $pdo->exec("INSERT INTO test VALUES (1, 2, 74, 3.1425, 'Foo', 'Bar')");
-    
-    echo "Test with Fetch with assoc&group".PHP_EOL;
+
+    echo "Test with Fetch with assoc & group".PHP_EOL;
     $stmt = $pdo->prepare("SELECT * FROM test");
     $stmt->execute();
     print_r($stmt->fetch(\PDO::FETCH_ASSOC | \PDO::FETCH_GROUP));
     
-    echo "Test with FetchAll with assoc&group".PHP_EOL;
+    echo "Test with FetchAll with assoc & group".PHP_EOL;
     $stmt = $pdo->prepare("SELECT * FROM test");
     $stmt->execute();
     print_r($stmt->fetchAll(\PDO::FETCH_ASSOC | \PDO::FETCH_GROUP));
     
-    echo "Test with Fetch with num&group".PHP_EOL;
+    echo "Test with Fetch with num & group".PHP_EOL;
     $stmt = $pdo->prepare("SELECT * FROM test");
     $stmt->execute();
     print_r($stmt->fetch(\PDO::FETCH_NUM | \PDO::FETCH_GROUP));
     
-    echo "Test with FetchAll with num&group".PHP_EOL;
+    echo "Test with FetchAll with num & group".PHP_EOL;
     $stmt = $pdo->prepare("SELECT * FROM test");
     $stmt->execute();
     print_r($stmt->fetchAll(\PDO::FETCH_NUM | \PDO::FETCH_GROUP));
+
+    echo "Test with Fetch with both (default) & group".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetch(\PDO::FETCH_GROUP));
+    
+    echo "Test with FetchAll with both (default) & group".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetchAll(\PDO::FETCH_GROUP));
+    
+    echo "Test with Fetch with both & group".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetch(\PDO::FETCH_BOTH | \PDO::FETCH_GROUP));
+    
+    echo "Test with FetchAll with both & group".PHP_EOL;
+    $stmt = $pdo->prepare("SELECT * FROM test");
+    $stmt->execute();
+    print_r($stmt->fetchAll(\PDO::FETCH_BOTH | \PDO::FETCH_GROUP));
 }
 
 test();


### PR DESCRIPTION
Fix #817 

Implements FETCH_GROUP and works with FETCH_ASSOC, FETCH_NUM and FETCH_BOTH.

Note that it only make sense to implement in `fetchAll`, as `fetch` only returns one row (but it is checked in the test case to be sure).