### PR TITLE
PDO: Fix NULL bound value handling (in order to work with foreign keys)

### DIFF
--- a/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
+++ b/src/PDO/Peachpie.Library.PDO/PDOStatement.cs
@@ -988,7 +988,10 @@ namespace Peachpie.Library.PDO
                 var enumerator = input_parameters.GetFastEnumerator();
                 while (enumerator.MoveNext())
                 {
-                    bound_params[enumerator.CurrentKey] = new BoundParam { Type = PARAM.PARAM_STR, Variable = enumerator.CurrentValue.ToString(Context), };
+                    bound_params[enumerator.CurrentKey] =
+                        enumerator.CurrentValue.IsNull
+                            ? new BoundParam { Type = PARAM.PARAM_NULL }
+                            : new BoundParam { Type = PARAM.PARAM_STR, Variable = enumerator.CurrentValue.ToString(Context), };
                 }
             }
 

--- a/tests/pdo/bindparam_002.php
+++ b/tests/pdo/bindparam_002.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace pdo\bindparam_002;
+
+function test()
+{
+	$pdo = new \PDO("sqlite::memory:");
+	$pdo->exec("PRAGMA foreign_keys = ON;");
+	$pdo->exec("CREATE TABLE posts (id INTEGER PRIMARY KEY)");
+	$pdo->exec("INSERT INTO posts (id) VALUES (null), (null), (null), (null)");
+	$pdo->exec("CREATE TABLE other (id INTEGER PRIMARY KEY, post_id INTEGER, FOREIGN KEY(post_id) REFERENCES posts(id))");
+	$pdo->exec("INSERT INTO other (post_id) VALUES (1), (1), (2)");
+
+	$stmt = $pdo->prepare("UPDATE other SET post_id=:post_id WHERE id=1");
+	$stmt->execute(array(":post_id" => 2));
+
+	$stmt = $pdo->prepare("SELECT * FROM other");
+	$stmt->execute();
+	print_r($stmt->fetchAll(\PDO::FETCH_ASSOC));
+
+	$stmt = $pdo->prepare("UPDATE other SET post_id=:post_id WHERE id=2");
+	$stmt->execute(array(":post_id" => NULL));
+
+	$stmt = $pdo->prepare("SELECT * FROM other");
+	$stmt->execute();
+	print_r($stmt->fetchAll(\PDO::FETCH_ASSOC));
+}
+
+test();
+
+echo "Done.";


### PR DESCRIPTION
Hello,

This one was complicated, but I'm glad I managed to fix it. My initial error was with SQLSRV driver but I managed to reproduce it in SQLite.

When `NULL` was used as a bound value, updating a value that was a foreign key would throw an exception regarding a conflict with the foreign key. It's actually because the `NULL` value was converted to an empty string when bound.

This fix check for IsNull and use the proper bind param.