### PR TITLE
Issue with array_pad using array as value

### DIFF
--- a/src/Peachpie.Library/Arrays.cs
+++ b/src/Peachpie.Library/Arrays.cs
@@ -842,7 +842,7 @@ namespace Pchp.Library
             // prepends items:
             if (length < 0)
             {
-                while (remains-- > 0) result.Add(value);
+                while (remains-- > 0) result.Add(value.DeepCopy());
             }
 
             // inserts items from source array
@@ -860,7 +860,7 @@ namespace Pchp.Library
             // appends items:
             if (length > 0)
             {
-                while (remains-- > 0) result.Add(value);
+                while (remains-- > 0) result.Add(value.DeepCopy());
             }
 
             // the result is inplace deeply copied on return to PHP code:

--- a/tests/arrays/array_combine.php
+++ b/tests/arrays/array_combine.php
@@ -1,0 +1,15 @@
+<?php
+namespace arrays\array_combine;
+
+function test($a, $b, $fn) {
+  print_r(array_combine($a, $b));
+  print_r($fn($a, $b));
+
+  $c = array_combine($a, array_pad(array(), count($a), array("foo" => "bar", "bar" => "foo")));
+  print_r($c);
+  // Update a specific subkey, should not mutate the others
+  $c["B"]["foo"] = "notbar";
+  print_r($c);
+}
+
+test(['a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D'], ['w' => 'W', 'x' => 'X', 'y' => 'Y', 'z' => 'Z'], 'array_combine');

--- a/tests/arrays/array_pad.php
+++ b/tests/arrays/array_pad.php
@@ -1,0 +1,15 @@
+<?php
+namespace arrays\array_pad;
+
+function test($a, $fn) {
+  print_r(array_pad(array(), 3, 5));
+  print_r($fn($a, 3, "foo"));
+
+  $p = array_pad(array(), 3, array("foo" => "bar", "bar" => "foo"));
+  print_r($p);
+  // Update a specific subkey, should not mutate the others
+  $p[1]["foo"] = "notbar";
+  print_r($p);
+}
+
+test(["test" => "test"], 'array_pad');


### PR DESCRIPTION

It took me a lot of soul-searching to find this little one.

There is an issue when using `array_pad` with an array as value.
It seems that the array is copied by reference and mutating it will mutate all the others.

I do not have the solution yet, but I've added the test cases for `array_pad` (and `array_combine`, since I discovered it through this one and I saw that no test was available).