### PR TITLE
array_fill: perform deepCopy on value to always use a new one

### DIFF
--- a/src/Peachpie.Library/Arrays.cs
+++ b/src/Peachpie.Library/Arrays.cs
@@ -782,7 +782,7 @@ namespace Pchp.Library
                 int last = startIndex + count;
                 for (int i = startIndex; i < last; i++)
                 {
-                    result.Add(i, value);
+                    result.Add(i, value.DeepCopy());
                 }
 
                 return result;

--- a/tests/arrays/array_fill.php
+++ b/tests/arrays/array_fill.php
@@ -1,0 +1,15 @@
+<?php
+namespace arrays\array_fill;
+
+function test($fn) {
+  print_r(array_fill(0, 2, "foo"));
+  print_r($fn(1, 3, "bar"));
+
+  $p = array_fill(0, 2, array("foo" => "bar", "bar" => "foo"));
+  print_r($p);
+  // Update a specific subkey, should not mutate the others
+  $p[1]["foo"] = "notbar";
+  print_r($p);
+}
+
+test('array_fill');


### PR DESCRIPTION
Similar to #829 but for array_fill.

I looked around to see if there was more similar functions (that duplicate a value over an array). I think it's all, unless you know of one?