### PR TITLE
Target .Net Standard 2.0 for Peachpie.AspNetCore.* projects

### DIFF
--- a/src/Peachpie.AspNetCore.Mvc/Peachpie.AspNetCore.Mvc.csproj
+++ b/src/Peachpie.AspNetCore.Mvc/Peachpie.AspNetCore.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Peachpie.AspNetCore.Mvc</AssemblyName>
     <PackageId>Peachpie.AspNetCore.Mvc</PackageId>

--- a/src/Peachpie.AspNetCore.Web/Peachpie.AspNetCore.Web.csproj
+++ b/src/Peachpie.AspNetCore.Web/Peachpie.AspNetCore.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Peachpie.AspNetCore.Web</AssemblyName>
     <PackageId>Peachpie.AspNetCore.Web</PackageId>

--- a/src/Peachpie.AspNetCore.Web/SynchronizedTextWriter.cs
+++ b/src/Peachpie.AspNetCore.Web/SynchronizedTextWriter.cs
@@ -17,10 +17,6 @@ namespace Peachpie.AspNetCore.Web
     sealed class SynchronizedTextWriter : TextWriter
     {
 
-#if NETSTANDARD2_0
-        private readonly char[] writeChars;
-#endif
-
         HttpResponse HttpResponse { get; }
 
         public override Encoding Encoding { get; }
@@ -28,13 +24,14 @@ namespace Peachpie.AspNetCore.Web
         /// <summary>Temporary buffer for encoded single-character.</summary>
         byte[] _encodedCharBuffer;
 
+#if NETSTANDARD2_0
+        readonly char[] _charBuffer = new char[1];
+#endif
+
         public SynchronizedTextWriter(HttpResponse response, Encoding encoding)
         {
             HttpResponse = response ?? throw new ArgumentNullException(nameof(response));
             Encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
-#if NETSTANDARD2_0
-            writeChars = new char[1];
-#endif
         }
 
         const int UTF8MaxByteLength = 6;
@@ -98,8 +95,8 @@ namespace Peachpie.AspNetCore.Web
 
 #if NETSTANDARD2_0
             // encode the char
-            writeChars[0] = value;
-            var nbytes = Encoding.GetBytes(writeChars, 0, 1, _encodedCharBuffer, 0);
+            _charBuffer[0] = value;
+            var nbytes = Encoding.GetBytes(_charBuffer, 0, 1, _encodedCharBuffer, 0);
 #else
             // encode the char on stack
             Span<char> chars = stackalloc char[1] { value };


### PR DESCRIPTION
Alright so here we are. Tries to fix #832 

The changes are... small? I expected more issue. It compiles fine in .Net Standard 2.0, except 2 methods in `Peachpie.AspNetCore.Web\SynchronizedTextWriter.cs`.

I choose to enable both .Net Standard and use conditional compiler directive so former code is left untouched for 2.1.

However, since the changes are very small, I wonder it would not be easier to simply enable only .Net Standard 2.0?

That said, I have no idea how to test it. Any pointers?