### PR TITLE
Fix DateInterval format (%a)

### DIFF
--- a/src/Peachpie.Library/DateTime/DateInterval.cs
+++ b/src/Peachpie.Library/DateTime/DateInterval.cs
@@ -66,11 +66,11 @@ namespace Pchp.Library.DateTime
         /// <summary>
         /// Exposed interface to access the total number of days, see <see cref="_days"/>
         /// </summary>
-        public PhpValue days { 
-            get {
-                return _days != null
-                    ? PhpValue.FromClr(_days.Value)
-                    : PhpValue.False;
+        public PhpValue days
+        {
+            get
+            {
+                return _days.HasValue ? _days.Value : PhpValue.False;
             }
             set { /* will not throw, but will do nothing */ }
         }

--- a/src/Peachpie.Library/DateTime/DateInterval.cs
+++ b/src/Peachpie.Library/DateTime/DateInterval.cs
@@ -79,9 +79,12 @@ namespace Pchp.Library.DateTime
 
         internal DateInterval(System.DateTime date1, System.DateTime date2)
         {
+            // For computing the total number of day, we do this without taking account the time part
+            days = (int)(date2.Date.Subtract(date1.Date)).TotalDays;
+            if (days < 0) days = -days;
+
             var span = date2 - date1;
 
-            days = (int)span.TotalDays;
             invert = span.Ticks < 0 ? 1 : 0;
 
             CalculateDifference(date1, date2, out y, out m, out span);

--- a/src/Peachpie.Library/DateTime/DateInterval.cs
+++ b/src/Peachpie.Library/DateTime/DateInterval.cs
@@ -61,7 +61,19 @@ namespace Pchp.Library.DateTime
         /// If the <see cref="DateInterval"/> object was created by <see cref="DateTime.diff"/>,
         /// then this is the total number of days between the start and end dates.
         /// </summary>
-        private readonly int? days = null;
+        private readonly int? _days = null;
+
+        /// <summary>
+        /// Exposed interface to access the total number of days, see <see cref="_days"/>
+        /// </summary>
+        public PhpValue days { 
+            get {
+                return _days != null
+                    ? PhpValue.FromClr(_days.Value)
+                    : PhpValue.False;
+            }
+            set { /* will not throw, but will do nothing */ }
+        }
 
         public int invert;
 
@@ -80,8 +92,8 @@ namespace Pchp.Library.DateTime
         internal DateInterval(System.DateTime date1, System.DateTime date2)
         {
             // For computing the total number of day, we do this without taking account the time part
-            days = (int)(date2.Date.Subtract(date1.Date)).TotalDays;
-            if (days < 0) days = -days;
+            _days = (int)(date2.Date.Subtract(date1.Date)).TotalDays;
+            if (_days < 0) _days = -_days;
 
             var span = date2 - date1;
 
@@ -317,7 +329,7 @@ namespace Pchp.Library.DateTime
 
                         //a Total number of days as a result of a DateTime::diff() or(unknown) otherwise   4, 18, 8123
                         case 'a':
-                            result.Append(days?.ToString(CultureInfo.InvariantCulture) ?? "(unknown)");
+                            result.Append(_days?.ToString(CultureInfo.InvariantCulture) ?? "(unknown)");
                             break;
 
                         //H Hours, numeric, at least 2 digits with leading 0    01, 03, 23

--- a/src/Peachpie.Library/DateTime/DateInterval.cs
+++ b/src/Peachpie.Library/DateTime/DateInterval.cs
@@ -215,7 +215,6 @@ namespace Pchp.Library.DateTime
         private protected void Initialize(TimeSpan ts)
         {
             _span = ts.Duration(); // absolutize the range
-            days = (int)ts.TotalDays;
             invert = ts.Ticks < 0 ? 1 : 0;
         }
 

--- a/src/Peachpie.Library/DateTime/DateInterval.cs
+++ b/src/Peachpie.Library/DateTime/DateInterval.cs
@@ -58,12 +58,10 @@ namespace Pchp.Library.DateTime
         }
 
         /// <summary>
-        /// </summary>
-        /// <remarks>
         /// If the <see cref="DateInterval"/> object was created by <see cref="DateTime.diff"/>,
         /// then this is the total number of days between the start and end dates.
-        /// </remarks>
-        public int days { get; set; }
+        /// </summary>
+        private readonly int? days = null;
 
         public int invert;
 
@@ -316,6 +314,9 @@ namespace Pchp.Library.DateTime
                             break;
 
                         //a Total number of days as a result of a DateTime::diff() or(unknown) otherwise   4, 18, 8123
+                        case 'a':
+                            result.Append(days?.ToString(CultureInfo.InvariantCulture) ?? "(unknown)");
+                            break;
 
                         //H Hours, numeric, at least 2 digits with leading 0    01, 03, 23
                         case 'H':

--- a/src/Peachpie.Library/DateTime/DateInterval.cs
+++ b/src/Peachpie.Library/DateTime/DateInterval.cs
@@ -61,7 +61,7 @@ namespace Pchp.Library.DateTime
         /// If the <see cref="DateInterval"/> object was created by <see cref="DateTime.diff"/>,
         /// then this is the total number of days between the start and end dates.
         /// </summary>
-        private readonly int? _days = null;
+        private protected readonly int? _days = null;
 
         /// <summary>
         /// Exposed interface to access the total number of days, see <see cref="_days"/>

--- a/src/Peachpie.Library/DateTime/DateInterval.cs
+++ b/src/Peachpie.Library/DateTime/DateInterval.cs
@@ -91,10 +91,6 @@ namespace Pchp.Library.DateTime
 
         internal DateInterval(System.DateTime date1, System.DateTime date2)
         {
-            // For computing the total number of day, we do this without taking account the time part
-            _days = (int)(date2.Date.Subtract(date1.Date)).TotalDays;
-            if (_days < 0) _days = -_days;
-
             var span = date2 - date1;
 
             invert = span.Ticks < 0 ? 1 : 0;
@@ -103,6 +99,9 @@ namespace Pchp.Library.DateTime
 
             Debug.Assert(span.Ticks >= 0); // absolutized
             _span = span;
+
+            // For computing the total number of day, we do this without taking account the time part
+            _days = Math.Abs((int)date2.Date.Subtract(date1.Date).TotalDays);
         }
 
         internal bool IsZero

--- a/tests/datetime/dateinterval_001.php
+++ b/tests/datetime/dateinterval_001.php
@@ -1,0 +1,55 @@
+<?php
+namespace date\dateinterval_001;
+
+function test() {
+  
+    echo "Checking format with date_diff null".PHP_EOL;
+    $interval = date_diff(new \DateTime(), new \DateTime());
+    echo print_r($interval->format('%r%a'), true).PHP_EOL;
+    echo print_r($interval->format('%r%d'), true).PHP_EOL;
+    echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
+
+    echo "Checking format with date_diff negative".PHP_EOL;
+    $interval = date_diff((new \DateTime())->add(new \DateInterval('P4D')), new \DateTime());
+    echo print_r($interval->format('%r%a'), true).PHP_EOL;
+    echo print_r($interval->format('%r%d'), true).PHP_EOL;
+    echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
+    echo PHP_EOL;
+
+    echo "Checking format with date_diff positive".PHP_EOL;
+    $interval = date_diff(new \DateTime(), (new \DateTime())->add(new \DateInterval('P2D')));
+    echo print_r($interval->format('%r%a'), true).PHP_EOL;
+    echo print_r($interval->format('%r%d'), true).PHP_EOL;
+    echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
+    echo PHP_EOL;
+
+    echo "Checking format with date_diff complex".PHP_EOL;
+    $interval = date_diff(\DateTime::createFromFormat('Ymd','20160423'), \DateTime::createFromFormat('Ymd H:i:s','20160402 15:16:17'));
+    echo print_r($interval->format('%r%a'), true).PHP_EOL;
+    echo print_r($interval->format('%r%d'), true).PHP_EOL;
+    echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
+    echo PHP_EOL;
+
+    echo "Checking format with date_diff complex without time".PHP_EOL;
+    $interval = date_diff(\DateTime::createFromFormat('Ymd','20200101'), \DateTime::createFromFormat('Ymd','20200714'));
+    echo print_r($interval->format('%r%a'), true).PHP_EOL;
+    echo print_r($interval->format('%r%d'), true).PHP_EOL;
+    echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
+    echo PHP_EOL;
+
+    echo "Checking format with date_diff complex with time".PHP_EOL;
+    $interval = date_diff(\DateTime::createFromFormat('Ymd H:i:s','20200101 09:16:52'), \DateTime::createFromFormat('Ymd','20200714'));
+    echo print_r($interval->format('%r%a'), true).PHP_EOL;
+    echo print_r($interval->format('%r%d'), true).PHP_EOL;
+    echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
+    echo PHP_EOL;
+    
+    echo "Checking format without date_diff = (unknown)".PHP_EOL;
+    $interval = new \DateInterval('P2D');
+    echo print_r($interval->format('%r%a'), true).PHP_EOL;
+    echo print_r($interval->format('%r%d'), true).PHP_EOL;
+    echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
+    echo PHP_EOL;
+}
+
+test();

--- a/tests/datetime/dateinterval_001.php
+++ b/tests/datetime/dateinterval_001.php
@@ -5,12 +5,15 @@ function test() {
   
     echo "Checking format with date_diff null".PHP_EOL;
     $interval = date_diff(new \DateTime(), new \DateTime());
+    $interval->days = 5;
+    echo gettype($interval->days) ."=". $interval->days .PHP_EOL;
     echo print_r($interval->format('%r%a'), true).PHP_EOL;
     echo print_r($interval->format('%r%d'), true).PHP_EOL;
     echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
 
     echo "Checking format with date_diff negative".PHP_EOL;
     $interval = date_diff((new \DateTime())->add(new \DateInterval('P4D')), new \DateTime());
+    echo gettype($interval->days) ."=". $interval->days .PHP_EOL;
     echo print_r($interval->format('%r%a'), true).PHP_EOL;
     echo print_r($interval->format('%r%d'), true).PHP_EOL;
     echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
@@ -18,6 +21,7 @@ function test() {
 
     echo "Checking format with date_diff positive".PHP_EOL;
     $interval = date_diff(new \DateTime(), (new \DateTime())->add(new \DateInterval('P2D')));
+    echo gettype($interval->days) ."=". $interval->days .PHP_EOL;
     echo print_r($interval->format('%r%a'), true).PHP_EOL;
     echo print_r($interval->format('%r%d'), true).PHP_EOL;
     echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
@@ -25,6 +29,7 @@ function test() {
 
     echo "Checking format with date_diff complex".PHP_EOL;
     $interval = date_diff(\DateTime::createFromFormat('Ymd','20160423'), \DateTime::createFromFormat('Ymd H:i:s','20160402 15:16:17'));
+    echo gettype($interval->days) ."=". $interval->days .PHP_EOL;
     echo print_r($interval->format('%r%a'), true).PHP_EOL;
     echo print_r($interval->format('%r%d'), true).PHP_EOL;
     echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
@@ -32,6 +37,7 @@ function test() {
 
     echo "Checking format with date_diff complex without time".PHP_EOL;
     $interval = date_diff(\DateTime::createFromFormat('Ymd','20200101'), \DateTime::createFromFormat('Ymd','20200714'));
+    echo gettype($interval->days) ."=". $interval->days .PHP_EOL;
     echo print_r($interval->format('%r%a'), true).PHP_EOL;
     echo print_r($interval->format('%r%d'), true).PHP_EOL;
     echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
@@ -39,6 +45,7 @@ function test() {
 
     echo "Checking format with date_diff complex with time".PHP_EOL;
     $interval = date_diff(\DateTime::createFromFormat('Ymd H:i:s','20200101 09:16:52'), \DateTime::createFromFormat('Ymd','20200714'));
+    echo gettype($interval->days) ."=". $interval->days .PHP_EOL;
     echo print_r($interval->format('%r%a'), true).PHP_EOL;
     echo print_r($interval->format('%r%d'), true).PHP_EOL;
     echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;
@@ -46,6 +53,7 @@ function test() {
     
     echo "Checking format without date_diff = (unknown)".PHP_EOL;
     $interval = new \DateInterval('P2D');
+    echo gettype($interval->days) ."=". $interval->days .PHP_EOL;
     echo print_r($interval->format('%r%a'), true).PHP_EOL;
     echo print_r($interval->format('%r%d'), true).PHP_EOL;
     echo print_r($interval->format('%m month, %d days, %I mins'), true).PHP_EOL;


### PR DESCRIPTION
Hello,

This little PR fixes the `%a` format used in DateInterval after a `date_diff()`.

The comments was already here, but not fully implemented (and the computation also, albeit not exactly correct) so I simply finished it.