### PR TITLE
array_unique: fix NULL value handling

### DIFF
--- a/src/Peachpie.Library/Arrays.cs
+++ b/src/Peachpie.Library/Arrays.cs
@@ -2456,9 +2456,8 @@ namespace Pchp.Library
         {
             if (array == null)
             {
-                //PhpException.ArgumentNull("array");
-                //return null;
-                throw new ArgumentNullException();
+                PhpException.ArgumentNull(nameof(array));
+                return null;
             }
 
             IComparer<PhpValue> comparer;

--- a/tests/arrays/array_unique.php
+++ b/tests/arrays/array_unique.php
@@ -1,0 +1,14 @@
+<?php
+namespace arrays\array_unique;
+
+function test($a, $fn) {
+    print_r($a);
+    print_r(array_unique($a));
+    print_r($fn($a));
+
+    $b = null;
+    $res = array_unique($b);
+    echo gettype($res) . "=" . $res . PHP_EOL;
+}
+
+test(["foo", "bar", "foo", 0, 1, 2, 0], 'array_unique');


### PR DESCRIPTION

The correct code was actually commented. PHP returns NULL when parameter is NULL.