### PR TITLE
com_dotnet extension: basic implementation (barely working)

### DIFF
--- a/Peachpie.sln
+++ b/Peachpie.sln
@@ -82,6 +82,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Peachpie.NET.SdkTests", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Peachpie.App.Tests", "src\Tests\Peachpie.App.Tests\Peachpie.App.Tests.csproj", "{C8A0A533-BB62-4CB5-8861-06522DCF5EC2}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Peachpie.Library.ComDotNet", "src\Peachpie.Library.ComDotNet\Peachpie.Library.ComDotNet.csproj", "{B9DE827D-79F5-4066-80C5-7535EB66B443}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Peachpie.Library.ComDotNet/Com.cs
+++ b/src/Peachpie.Library.ComDotNet/Com.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Pchp.Core;
+
+namespace Peachpie.Library.ComDotNet
+{
+    /// <summary>
+    /// COM object
+    /// <para>TODO : implements VARIANT and inherit from it, which would allow returning VARIANT object from __call and __get
+    /// and working with it, see test case com_dotnet/com.php</para>
+    /// </summary>
+    [PhpType(PhpTypeAttribute.InheritName), PhpExtension("com_dotnet")]
+    public class COM
+    {
+        #region Private members
+
+        object comObject = null;
+
+        const BindingFlags MemberAccessCom =
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase;
+
+        #endregion
+
+        #region Construction
+
+        public COM(Context ctx, string module_name)
+        {
+            __construct(ctx, module_name);
+        }
+
+        [PhpFieldsOnlyCtor]
+        protected COM()
+        {
+        }
+
+        public virtual void __construct(Context ctx, string module_name)
+        {
+            var comType = Type.GetTypeFromProgID(module_name);
+            if (comType == null)
+                return;
+
+            comObject = Activator.CreateInstance(comType);
+        }
+
+        public virtual void __construct(Context ctx, string module_name, string server_name)
+        {
+            var comType = Type.GetTypeFromProgID(module_name, server_name);
+            if (comType == null)
+                return;
+
+            comObject = Activator.CreateInstance(comType);
+        }
+
+        public virtual void __construct(Context ctx, string module_name, string server_name, int code_page)
+        {
+            throw new NotSupportedException();
+        }
+
+        public virtual void __construct(Context ctx, string module_name, string server_name, int code_page, string typelib)
+        {
+            throw new NotSupportedException();
+        }
+
+        #endregion
+
+        #region Magic methods
+
+        /// <summary>
+        /// Special field containing runtime fields.
+        /// </summary>
+        /// <remarks>
+        /// The field is handled by runtime and is not intended for direct use.
+        /// Magic methods for property access are ignored without runtime fields.
+        /// </remarks>
+        [CompilerGenerated]
+        internal PhpArray __peach__runtimeFields = null;
+
+        public PhpValue __call(string name, PhpArray arguments)
+        {
+            if (comObject == null)
+                return PhpValue.Null;
+
+            var parameters = arguments.GetValues().Select(v => v.ToClr()).ToArray();
+
+            var result = comObject.GetType().InvokeMember(
+                name, MemberAccessCom | BindingFlags.InvokeMethod, null, comObject, parameters);
+
+            return PhpValue.FromClr(result);
+        }
+
+        public virtual PhpValue __get(string name)
+        {
+            if (comObject == null)
+                return PhpValue.Null;
+
+            var prop = comObject.GetType().InvokeMember(
+                name, MemberAccessCom | BindingFlags.GetProperty, null, comObject, null);
+            
+            return prop != null 
+                ? PhpValue.FromClr(prop)
+                : PhpValue.Null;
+        }
+
+        public virtual bool __set(string name, PhpValue value)
+        {
+            if (comObject == null)
+                return false;
+
+            comObject.GetType().InvokeMember(
+                name, MemberAccessCom | BindingFlags.SetProperty, null, comObject, new object[1] { value.ToClr() });
+
+            return true;
+        }
+
+        #endregion
+    }
+}

--- a/src/Peachpie.Library.ComDotNet/ComDotNet.cs
+++ b/src/Peachpie.Library.ComDotNet/ComDotNet.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Pchp.Core;
+
+namespace Peachpie.Library.ComDotNet
+{
+    /// <summary>
+    /// COM functions
+    /// </summary>
+    [PhpExtension("com_dotnet")]
+    public static class ComDotNet
+    {
+        /// <summary>
+        /// Generate a globally unique identifier (GUID)
+        /// </summary>
+        public static PhpString com_create_guid()
+        {
+            return Guid.NewGuid().ToString("B");
+        }
+    }
+
+}

--- a/src/Peachpie.Library.ComDotNet/Peachpie.Library.ComDotNet.csproj
+++ b/src/Peachpie.Library.ComDotNet/Peachpie.Library.ComDotNet.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>Peachpie.Library.ComDotNet</AssemblyName>
+    <PackageId>Peachpie.Library.ComDotNet</PackageId>
+    <PackageTags>peachpie;library;com;dotnet;com_dotnet</PackageTags>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Description>Peachpie PHP language library functions for COM/.Net interoperability on Windows.</Description>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Peachpie.Runtime\Peachpie.Runtime.csproj" />
+    <ProjectReference Include="..\Peachpie.Library\Peachpie.Library.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Peachpie.Library.ComDotNet/Properties/AssemblyInfo.cs
+++ b/src/Peachpie.Library.ComDotNet/Properties/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+﻿using System.Reflection;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyProduct("Peachpie.Library.ComDotNet")]
+[assembly: AssemblyTrademark("")]
+
+// annotates this library as a php extension,
+// all its public static methods with compatible signatures will be seen as global functions to php scope
+[assembly: Pchp.Core.PhpExtension("com_dotnet")]

--- a/src/Tests/Peachpie.ScriptTests/Peachpie.ScriptTests.csproj
+++ b/src/Tests/Peachpie.ScriptTests/Peachpie.ScriptTests.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\PDO\Peachpie.Library.PDO\Peachpie.Library.PDO.csproj" />
     <ProjectReference Include="..\..\Peachpie.CodeAnalysis\Peachpie.CodeAnalysis.csproj" />
     <ProjectReference Include="..\..\Peachpie.Library.Graphics\Peachpie.Library.Graphics.csproj" />
+    <ProjectReference Include="..\..\Peachpie.Library.ComDotNet\Peachpie.Library.ComDotNet.csproj" />
     <ProjectReference Include="..\..\Peachpie.Library.Network\Peachpie.Library.Network.csproj" />
     <ProjectReference Include="..\..\Peachpie.Library.Scripting\Peachpie.Library.Scripting.csproj" />
     <ProjectReference Include="..\..\Peachpie.Library\Peachpie.Library.csproj" />

--- a/src/Tests/Peachpie.ScriptTests/ScriptsTest.cs
+++ b/src/Tests/Peachpie.ScriptTests/ScriptsTest.cs
@@ -29,6 +29,7 @@ namespace ScriptsTest
             typeof(Peachpie.Library.Scripting.Standard).Assembly.Location,
             typeof(Peachpie.Library.XmlDom.XmlDom).Assembly.Location,
             typeof(Peachpie.Library.Network.CURLFunctions).Assembly.Location,
+            typeof(Peachpie.Library.ComDotNet.COM).Assembly.Location,
         };
 
         static readonly Context.IScriptingProvider _provider = Context.DefaultScriptingProvider; // use IScriptingProvider singleton 

--- a/tests/com_dotnet/com.php
+++ b/tests/com_dotnet/com.php
@@ -1,0 +1,30 @@
+<?php
+namespace com_dotnet\com;
+
+function test() {
+    if (!extension_loaded("com_dotnet")) {
+        echo "Extension com_dotnet not loaded";
+        return;
+    }
+
+    echo "testing fso" .PHP_EOL;
+    $fso = new \COM('Scripting.FileSystemObject');
+    echo !empty($fso->GetTempName()) . PHP_EOL;
+    // echo $fso->GetSpecialFolder(0) . PHP_EOL; // <- Fails (COM_Object)
+    $drives = $fso->Drives;
+    echo gettype($drives).PHP_EOL;
+    foreach($drives as $d) {
+       //echo $d.PHP_EOL; // <- Fails (COM_Object)
+       $dO = $fso->GetDrive($d); 
+       //echo $dO->DriveLetter.PHP_EOL; // <- Fails (COM_Object)
+       break;
+    }
+
+    echo "testing Shell" .PHP_EOL;
+    $shell = new \COM('WScript.Shell');
+    echo $shell->CurrentDirectory . PHP_EOL;
+    $shell->CurrentDirectory = "C:\\";
+    echo $shell->CurrentDirectory . PHP_EOL;
+}
+
+test();

--- a/tests/com_dotnet/com_create_guid.php
+++ b/tests/com_dotnet/com_create_guid.php
@@ -1,0 +1,13 @@
+<?php
+namespace com_dotnet\com_create_guid;
+
+function test() {
+    if (!extension_loaded("com_dotnet")) {
+        echo "Extension com_dotnet not loaded";
+        return;
+    }
+
+    echo !empty(com_create_guid()) . PHP_EOL;
+}
+
+test();


### PR DESCRIPTION
See #834 

I started to work on a basic implementation on [extension `com_dotnet` ](https://www.php.net/manual/en/book.com.php)

**What works:**
- Creating [COM object](https://www.php.net/manual/en/class.com.php)
  - codepage / typelib not supported
- Calling methods with arguments _which returns a simple value type (not COM objects)_
- Getting / Setting properties _for value types (not COM objects)_
- [com_create_guid()](https://www.php.net/manual/en/function.com-create-guid.php)

**What is missing:**

Almost everything...! But the main work would revolve around implementing the [Variant class](https://www.php.net/manual/en/class.variant.php) so the COM class could inherit from it. Also this class would be used for handling complex COM object which is not working at all right now.

**What should not be supported:**

- Creating [dotnet object](https://www.php.net/manual/en/class.dotnet.php) as .Net framework 4.0 and later are not supported.
