### PR TITLE
setcookie: fix when name or value are NULL

### DIFF
--- a/src/Peachpie.AspNetCore.Web/RequestContextCore.cs
+++ b/src/Peachpie.AspNetCore.Web/RequestContextCore.cs
@@ -123,7 +123,7 @@ namespace Peachpie.AspNetCore.Web
 
         void IHttpPhpContext.AddCookie(string name, string value, DateTimeOffset? expires, string path, string domain, bool secure, bool httpOnly)
         {
-            _httpctx.Response.Cookies.Append(name, value ?? "", new CookieOptions()
+            _httpctx.Response.Cookies.Append(name, value ?? string.Empty, new CookieOptions()
             {
                 Expires = expires,
                 Path = path,

--- a/src/Peachpie.AspNetCore.Web/RequestContextCore.cs
+++ b/src/Peachpie.AspNetCore.Web/RequestContextCore.cs
@@ -123,7 +123,7 @@ namespace Peachpie.AspNetCore.Web
 
         void IHttpPhpContext.AddCookie(string name, string value, DateTimeOffset? expires, string path, string domain, bool secure, bool httpOnly)
         {
-            _httpctx.Response.Cookies.Append(name, value, new CookieOptions()
+            _httpctx.Response.Cookies.Append(name, value ?? "", new CookieOptions()
             {
                 Expires = expires,
                 Path = path,

--- a/src/Peachpie.Library/Web.cs
+++ b/src/Peachpie.Library/Web.cs
@@ -354,12 +354,14 @@ namespace Pchp.Library
             var httpctx = ctx.HttpPhpContext;
             if (httpctx == null)
             {
+                // TODO: PHP actually modifies internal headers even on CLI
                 return false;
             }
 
             if (string.IsNullOrEmpty(name))
             {
-                PhpException.InvalidArgument(nameof(name));
+                // TODO: "Cookie names must not be empty"
+                PhpException.InvalidArgument(nameof(name), Resources.Resources.arg_empty);
                 return false;
             }
 

--- a/src/Peachpie.Library/Web.cs
+++ b/src/Peachpie.Library/Web.cs
@@ -357,6 +357,12 @@ namespace Pchp.Library
                 return false;
             }
 
+            if (string.IsNullOrEmpty(name))
+            {
+                PhpException.InvalidArgument(nameof(name));
+                return false;
+            }
+
             DateTimeOffset? expires;
             if (expire > 0)
             {


### PR DESCRIPTION

In [setcookie](https://www.php.net/manual/en/function.setcookie.php):

PHP behavior 

- when name is NULL or empty: return FALSE and add warning "Cookie names must not be empty"
- when value is NULL : return TRUE

PeachPie behavior
- when name is NULL or empty: throw exception
- when value is NULL: throw exception

This PR aims to match PHP behavior.
