### PR TITLE
Fix nested array aliasing in array_merge_recursive

### DIFF
--- a/src/Peachpie.Runtime/PhpHashtable.cs
+++ b/src/Peachpie.Runtime/PhpHashtable.cs
@@ -833,17 +833,22 @@ namespace Pchp.Core
         public void AddTo(PhpHashtable/*!*/dst, bool deepCopy)
         {
             if (dst == null)
-                throw new ArgumentNullException("dst");
+                throw new ArgumentNullException(nameof(dst));
 
             var enumerator = this.GetFastEnumerator();
             while (enumerator.MoveNext())
             {
-                var val = deepCopy ? enumerator.CurrentValue.DeepCopy() : enumerator.CurrentValue;
-                var key = enumerator.CurrentKey;
-                if (key.IsInteger)
+                var entry = enumerator.Current;
+                var val = deepCopy ? entry.Value.DeepCopy() : entry.Value;
+
+                if (entry.Key.IsInteger)
+                {
                     dst.Add(val);
+                }
                 else
-                    dst.Add(key, val);
+                {
+                    dst.Add(entry.Key, val);
+                }
             }
         }
 

--- a/src/Peachpie.Runtime/Variables.cs
+++ b/src/Peachpie.Runtime/Variables.cs
@@ -565,6 +565,7 @@ namespace Pchp.Core
         public static PhpArray? AsArray(this PhpValue value)
         {
             return (value.Object is PhpAlias alias ? alias.Value.Object : value.Object) as PhpArray;
+            //return value.Object as PhpArray ?? (value.Object is PhpAlias alias ? alias.Value.Object as PhpArray : null);
         }
 
         /// <summary>

--- a/tests/arrays/array_merge_recursive_001.php
+++ b/tests/arrays/array_merge_recursive_001.php
@@ -1,0 +1,26 @@
+<?php
+namespace arrays\array_merge_recursive_001;
+
+function test() {
+  $a1 = [
+    'sub' => [
+      'sub' => [
+        'foo' => 0
+      ]
+    ]
+  ];
+
+  $a2 = [
+    'sub' => [
+      'sub' => [
+        'foo' => 1
+      ]
+    ]
+  ];
+
+  $res = array_merge_recursive($a1, $a2);
+
+  print_r($a1);
+}
+
+test();

--- a/tests/arrays/array_merge_recursive_002.php
+++ b/tests/arrays/array_merge_recursive_002.php
@@ -1,0 +1,37 @@
+<?php
+namespace arrays\array_merge_recursive_002;
+
+function test() {
+  $a1 = [
+    'foo' => 'bar',
+    'range' => [
+      'px' => [
+        'min' => 0,
+        'max' => 100,
+        'step' => 1
+      ]
+    ],
+    42
+  ];
+
+  $a2 = [
+    24,
+    'range' => [
+      'px' => [
+        'min' => 1,
+        'max' => 200
+      ]
+    ],
+    'baz' => 'baz'
+  ];
+
+  $res = array_merge_recursive($a1, $a2);
+  $res['range']['px']['step'] = 5;
+  $res['other'] = 'other';
+
+  print_r($a1);
+  print_r($a2);
+  print_r($res);
+}
+
+test();


### PR DESCRIPTION
Fixes #868

Removes unused `deepCopy` argument of `MergeRecursiveInternal` (only `true` was passed to it anyway) and adds `wasDeepCopied` instead. It's `true` on the first merging level (thus preventing repeated deep copying), but `false` in the nested arrays, causing the necessary calls to `DeepCopy` to be performed.