### PR TITLE
Feature/datetime fix

### DIFF
--- a/src/Peachpie.Library/DateTime/DatePeriod.cs
+++ b/src/Peachpie.Library/DateTime/DatePeriod.cs
@@ -74,7 +74,7 @@ namespace Pchp.Library.DateTime
 
         IEnumerator<DateTimeInterface> IEnumerable<DateTimeInterface>.GetEnumerator()
         {
-            DateTimeImmutable current = start as DateTimeImmutable ?? (start as DateTime)?.AsDateTimeImmutable() ?? throw new InvalidOperationException();
+            var current = DateTimeImmutable.createFromInterface(start);
             
             if (include_start_date)
             {
@@ -95,14 +95,12 @@ namespace Pchp.Library.DateTime
             {
                 current = current.add(interval);
 
-                if (end != null && DateTimeFunctions.GetDateTimeFromInterface(end, out var end_datetime, out _))
+                if (end != null && DateTimeFunctions.CompareTime(current, end) > 0)
                 {
-                    if (current.Time > end_datetime)
-                    {
-                        yield break;
-                    }
+                    yield break;
                 }
-                else if (index >= recurrences)
+                
+                if (index >= recurrences)
                 {
                     yield break;
                 }

--- a/src/Peachpie.Library/DateTime/DateTimeFunctions.cs
+++ b/src/Peachpie.Library/DateTime/DateTimeFunctions.cs
@@ -1471,25 +1471,25 @@ namespace Pchp.Library.DateTime
         /// Parses a string containing an English date format into a UNIX timestamp relative to the current time.
         /// </summary>
         /// <param name="ctx">Runtime context.</param>
-        /// <param name="time">String containing time definition</param>
+        /// <param name="datetime">String containing time definition</param>
         /// <returns>Number of seconds since 1/1/1970 or -1 on failure.</returns>
         [return: CastToFalse]
-        public static long strtotime(Context ctx, string time)
+        public static long strtotime(Context ctx, string datetime)
         {
-            return StringToTime(ctx, time, System_DateTime.UtcNow);
+            return StringToTime(ctx, datetime, System_DateTime.UtcNow);
         }
 
         /// <summary>
         /// Parses a string containing an English date format into a UNIX timestamp relative to a specified time.
         /// </summary>
         /// <param name="ctx">Runtime context.</param>
-        /// <param name="time">String containing time definition.</param>
-        /// <param name="start">Timestamp (seconds from 1970) to which is the new timestamp counted.</param>
+        /// <param name="datetime">String containing time definition.</param>
+        /// <param name="baseTimestamp">Timestamp (seconds from 1970) to which is the new timestamp counted.</param>
         /// <returns>Number of seconds since 1/1/1970 or -1 on failure.</returns>
         [return: CastToFalse]
-        public static long strtotime(Context ctx, string time, long start)
+        public static long strtotime(Context ctx, string datetime, long baseTimestamp)
         {
-            return StringToTime(ctx, time, DateTimeUtils.UnixTimeStampToUtc(start));
+            return StringToTime(ctx, datetime, DateTimeUtils.UnixTimeStampToUtc(baseTimestamp));
         }
 
         /// <summary>

--- a/src/Peachpie.Library/DateTime/DateTimeInterface.cs
+++ b/src/Peachpie.Library/DateTime/DateTimeInterface.cs
@@ -11,7 +11,9 @@ namespace Pchp.Library.DateTime
     [PhpType(PhpTypeAttribute.InheritName), PhpExtension(PhpExtensionAttribute.KnownExtensionNames.Date)]
     public interface DateTimeInterface
     {
-        public class _statics   // nested "_statics" class is understood by compiler and runtime, contained readonly/const fields are treated as containing class's constants
+        // nested "_statics" class is understood by compiler and runtime, contained readonly/const fields are treated as containing class's constants
+        // see https://docs.peachpie.io/api/assembly/compiled-class/#additional-class-members
+        public class _statics
         {
             // following can be moved into the containing class once C# compiler allows it (or using IL hack)
 

--- a/src/Peachpie.Library/DateTime/DateTimeZone.cs
+++ b/src/Peachpie.Library/DateTime/DateTimeZone.cs
@@ -134,17 +134,19 @@ namespace Pchp.Library.DateTime
         public virtual int getOffset(Library.DateTime.DateTime datetime)
         {
             if (_timezone == null)
+            {
                 //return false;
                 throw new InvalidOperationException();
+            }
 
             if (datetime == null)
             {
                 //PhpException.ArgumentNull("datetime");
                 //return false;
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(datetime));
             }
 
-            return (int)_timezone.BaseUtcOffset.TotalSeconds + (_timezone.IsDaylightSavingTime(datetime.Time) ? 3600 : 0);
+            return (int)_timezone.BaseUtcOffset.TotalSeconds + (_timezone.IsDaylightSavingTime(datetime.LocalTime) ? 3600 : 0);
         }
 
         //public array getTransitions ([ int $timestamp_begin [, int $timestamp_end ]] )

--- a/tests/datetime/datetime_001.php
+++ b/tests/datetime/datetime_001.php
@@ -1,0 +1,14 @@
+<?php
+namespace date\datetime_001;
+
+function test() {
+    $dt = new \DateTime('2021-03-06 17:19:12 -5:00');
+    $obj = json_decode(json_encode($dt));
+
+    // timezone_type: 1, timezone: -05:00
+    echo "timezone_type: ", $obj->timezone_type, ", timezone: ", $obj->timezone, PHP_EOL;
+}
+
+test();
+
+echo "Done.";


### PR DESCRIPTION
- fixes https://github.com/peachpiecompiler/peachpie/issues/921
- code cleanup
- fixes parameter names for datetime functions so they match PHP' names
- changes DateTime and DateTimeImmutable internals, now the datetime is stored as a local kind instead of UTF which complies with how PHP works