### PR TITLE
Fix issue #974

### DIFF
--- a/src/Peachpie.Library/pcre.cs
+++ b/src/Peachpie.Library/pcre.cs
@@ -981,7 +981,8 @@ namespace Pchp.Library
             {
                 var g = groups[i];
                 var value = (g.Success || !unmatchedAsNull) ? g.Value : null;
-                var item = NewArrayItem(value, g.Index, offsetCapture);
+                int index = g.Success ? g.Index : -1;
+                var item = NewArrayItem(value, index, offsetCapture);
 
                 // All groups should be named.
                 if (g.IsNamedGroup)

--- a/tests/pcre/preg_match_006.php
+++ b/tests/pcre/preg_match_006.php
@@ -1,0 +1,8 @@
+<?php
+namespace pcre\preg_match_006;
+
+preg_match('/(?P<fooname>foo)?(bar)/', 'bar', $matches, PREG_OFFSET_CAPTURE);
+
+$is_fooname = isset( $matches['fooname'] ) && -1 !== $matches['fooname'][1];
+
+echo "is_fooname:" . ($is_fooname ? "true" : "false") . "\n"; //is_fooname:false


### PR DESCRIPTION
Fix issue[#974](https://github.com/peachpiecompiler/peachpie/issues/974)

**Reason:**
`preg_match` should return -1 index when the group is not matched. Actual implementation returns 0 even the `Success` property of the group match is false. After that, the returned result acts as the unmatched group is presented on offset 0, which is incorrect.
**Solution:**
- Adjust the `GroupsToPhpArray` method by rewriting the `index` value to -1 when the `Success` property is false
- The test is a part of the solution to verify correct functionality.