### PR TITLE
Fix debug message - wrong parameter order

### DIFF
--- a/src/Peachpie.Library/Mail.cs
+++ b/src/Peachpie.Library/Mail.cs
@@ -22,7 +22,7 @@ namespace Pchp.Library
             to = (to != null) ? to.Replace("\r\n", " ").Replace('\n', ' ') : "";
             subject = (subject != null) ? subject.Replace("\r\n", " ").Replace('\n', ' ') : "";
 
-            Debug.WriteLine("mail('{0}','{1}','{2}','{3}')", "MAILER", to, subject, message, additional_headers);
+            Debug.WriteLine("mail('{0}','{1}','{2}','{3}')", to, subject, message, additional_headers);
 
             var config = ctx.Configuration.Core;
 

--- a/src/Peachpie.Library/Mail.cs
+++ b/src/Peachpie.Library/Mail.cs
@@ -22,7 +22,7 @@ namespace Pchp.Library
             to = (to != null) ? to.Replace("\r\n", " ").Replace('\n', ' ') : "";
             subject = (subject != null) ? subject.Replace("\r\n", " ").Replace('\n', ' ') : "";
 
-            Debug.WriteLine("MAILER", "mail('{0}','{1}','{2}','{3}')", to, subject, message, additional_headers);
+            Debug.WriteLine("mail('{0}','{1}','{2}','{3}')", "MAILER", to, subject, message, additional_headers);
 
             var config = ctx.Configuration.Core;
 


### PR DESCRIPTION
Method signature - `public static void WriteLine (string format, params object?[] args);` (https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.debug.writeline?view=net-5.0#System_Diagnostics_Debug_WriteLine_System_String_System_Object___)

Inspired by https://habr.com/ru/company/pvs-studio/blog/573296#problemy-s-writeline