### PR TITLE
Feature/kendallb/mysql wrapping performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -279,3 +279,6 @@ $RECYCLE.BIN/
 *.lnk
 **/launchSettings.json
 **/Peachpie.Version.props
+
+# Ignore Rider files
+.idea/

--- a/src/Peachpie.Library.MySql/MySqlExtensions.cs
+++ b/src/Peachpie.Library.MySql/MySqlExtensions.cs
@@ -101,12 +101,13 @@ namespace Peachpie.Library.MySql
         /// <param name="object">Reference to object.</param>
         /// <param name="method">Lazily created method used ot obtain the underlying value.</param>
         /// <param name="getterMethodName">Method name used to obtain the underlying value.</param>
+        /// <param name="alternateMethodName">Alternate method name used to obtain the underlying value.</param>
         /// <returns>Value of type <typeparamref name="TResult"/>.</returns>
         /// <remarks>Used to get an underlying value of wrapping classes like the ones provided by MiniProfiler.</remarks>
         /// <exception cref="ArgumentNullException"><paramref name="object"/> is null.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="getterMethodName"/> is not defined on <paramref name="object"/>.</exception>
         /// <exception cref="NullReferenceException"><paramref name="object"/>' getter method returned null or an unexpected value.</exception>
-        static TResult/*!*/GetUnderlyingValue<TIn, TResult>(TIn @object, ref MethodInfo method, string getterMethodName) where TResult : class
+        static TResult/*!*/GetUnderlyingValue<TIn, TResult>(TIn @object, ref MethodInfo method, string getterMethodName, string alternateMethodName = null) where TResult : class
         {
             // we have TResult in most cases:
             if (@object is TResult result)
@@ -123,7 +124,8 @@ namespace Peachpie.Library.MySql
             if (method == null)
             {
                 method = @object.GetType().GetMethod(getterMethodName, BindingFlags.Instance | BindingFlags.Public)
-                         ?? throw new InvalidOperationException($"'{getterMethodName}' method could not be resolved for {@object.GetType().Name}.");
+                    ?? (alternateMethodName != null ? @object.GetType().GetMethod(alternateMethodName, BindingFlags.Instance | BindingFlags.Public) : null)
+                    ?? throw new InvalidOperationException($"'{getterMethodName}' method could not be resolved for {@object.GetType().Name}.");
             }
 
             // checks
@@ -138,7 +140,7 @@ namespace Peachpie.Library.MySql
         /// Casts or unwraps given <see cref="IDbCommand"/> to <see cref="MySqlCommand"/>.
         /// </summary>
         /// <returns><see cref="IDbCommand"/> might be wrapped into another class (usually DB profiler class like MiniProfiler).</returns>
-        public static MySqlCommand AsMySqlCommand(this IDbCommand command) => GetUnderlyingValue<IDbCommand, MySqlCommand>(command, ref s_iternalCommandMethod, "get_InternalCommand");
+        public static MySqlCommand AsMySqlCommand(this IDbCommand command) => GetUnderlyingValue<IDbCommand, MySqlCommand>(command, ref s_iternalCommandMethod, "get_WrappedCommand", "get_InternalCommand");
 
         /// <summary>
         /// Casts or unwraps given <see cref="IDbCommand"/> to <see cref="MySqlCommand"/>.


### PR DESCRIPTION
Improve runtime performance of unwrapping MySQL connections, readers and commands.

I am not sure why you did it this way with a ConcurrentDictionary?

var method = lazyCache.GetOrAdd(
    @object.GetType(),
    type => type.GetMethod(getterMethodName, BindingFlags.Instance | BindingFlags.Public))
    ?? throw new InvalidOperationException($"'{getterMethodName}' method could not be resolved for {@object.GetType().Name}.");

As far as I can tell from reading the code there are three separater concurrent dictionaries, one for each of the types we are resolving. While it works, I do question if we want that much overhead at runtime every time we need to cast a value that has been wrapped? While the code will early out nicely when the type is not wrapped, if it is wrapped it is always going to hit the concurrent dictionary. That is going to be much slower than my original code for two reasons a) the concurrent dictionary is going to use locking to ensure exclusive access (expensive) and b) its going to be using hashing to look up the value. The dictionary is only going to have one value in it per type (as there are three dictionaries; it is not shared).

My original code simply uses a static global variable for the getting method, which is very fast to use. The only real overhead is the invoking of the function to get the mapped value, but that should be way less than a concurrent dictionary? And it also avoids any locking. Sure, you can potentially get a race condition when multiple threads need to map a connection for the first time, but that's OK because I always write my code to assume a last in wins. So if 10 threads all hit the code at the same time, they will all perform the same reflection work to get the appropriate method, do the cast and then update the global variable. It does not really matter which one happens to get in last because the value will always get updated correctly in the end. I am pretty positive that for references, .net guarantees atomic updates to those values, so you don't need to worry about one thread happening to read another threads half baked value.

Finally the dictionary is not initialized (I assume to avoid the overhead of the storage at runtime). If you use a static global variable, you won't need to bother with that since you are just managing the reference?

Update to support the coming change for wrapped commands in MiniProfiler:

https://github.com/MiniProfiler/dotnet/issues/599