### PR TITLE
Feature/local debugging

### DIFF
--- a/build/dummy-net/dummy-net.msbuildproj
+++ b/build/dummy-net/dummy-net.msbuildproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Peachpie.NET.Sdk/1.0.0-dev">
+
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup Condition=" '$(DisableImplicitPeachpieReferences)' != 'true' ">
+	<PackageReference Include="Peachpie.RequestHandler" Version="$(PeachpieVersion)" PrivateAssets="Build" />
+	<PackageReference Include="Peachpie.App" Version="$(PeachpieVersion)" PrivateAssets="Build" />
+	<PackageReference Include="Peachpie.Library.PDO" Version="$(PeachpieVersion)" PrivateAssets="Build" />
+	<PackageReference Include="Peachpie.Library.PDO.MySQL" Version="$(PeachpieVersion)" PrivateAssets="Build" />
+	<PackageReference Include="Peachpie.Library.PDO.SqlSrv" Version="$(PeachpieVersion)" PrivateAssets="Build" />
+	<PackageReference Include="Peachpie.Library.PDO.Sqlite" Version="$(PeachpieVersion)" PrivateAssets="Build" />
+  </ItemGroup>
+
+</Project>

--- a/build/update-cache.ps1
+++ b/build/update-cache.ps1
@@ -5,7 +5,7 @@
 
 param([string]$version = "1.0.0", [string]$suffix = "dev")
 
-# We suppose the global package source is in the default location 
+# We suppose the global package source is in the default location
 $rootDir = [System.IO.Path]::GetFullPath("$PSScriptRoot/..")
 Write-Host "Root at" $rootDir
 $packagesSource = (Resolve-Path "~/.nuget/packages").Path
@@ -20,7 +20,7 @@ Write-Host -f green "Deleting '$version-$suffix' packages from '$packagesSource'
     }
 }
 
-## Clean up the installed tool settings so that no old dependencies hang in there 
+## Clean up the installed tool settings so that no old dependencies hang in there
 #$toolFolder = "$packagesSource/.tools/Peachpie.Compiler.Tools/$version-$suffix"
 #if (Test-Path $toolFolder) {
 #    Remove-Item -Recurse -Force $toolFolder
@@ -35,3 +35,4 @@ Write-Host -f green "Deleting '$version-$suffix' packages from '$packagesSource'
 # Reinstall the packages by restoring a dummy project that depends on them
 Write-Host -f green "Installing packages to nuget cache ..."
 dotnet restore "$rootDir/build/dummy"
+dotnet restore "$rootDir/build/dummy-net"


### PR DESCRIPTION
Add support for local builds of .net 4.61. I need to use this to be able to build correctly and debug .net 4.61 versions of the library. I cannot seem to debug .net standard. Can we somehow get this into the master tree as well?