### PR TITLE
Make sure to double the size of the array if we run out of space, but…

### DIFF
--- a/src/Peachpie.Runtime/Collections/ValueList`1.cs
+++ b/src/Peachpie.Runtime/Collections/ValueList`1.cs
@@ -92,7 +92,7 @@ namespace Pchp.Core.Collections
         {
             if (Capacity < capacity)
             {
-                Capacity = capacity;
+                Capacity = Math.Max(capacity, Capacity * 2);
             }
         }
 


### PR DESCRIPTION
When processing ICollections, we need to also use the doubling the size array algorithm to ensure we eventually have enough space when processing massive strings.