### PR TITLE
Fix php value conversion for sbyte and short

### DIFF
--- a/src/Peachpie.Runtime/PhpValue.cs
+++ b/src/Peachpie.Runtime/PhpValue.cs
@@ -1281,6 +1281,8 @@ namespace Pchp.Core
                 if (value.GetType() == typeof(byte[])) return Create(new PhpString((byte[])value));
                 if (value.GetType() == typeof(decimal)) return Create((double)(decimal)value); // downcast to double
                 if (value.GetType() == typeof(IntStringKey)) return Create((IntStringKey)value);
+                if (value.GetType() == typeof(sbyte)) return Create((int)System.Convert.ToInt32(value));
+                if (value.GetType() == typeof(short)) return Create((int)System.Convert.ToInt32(value));
 
                 // object        
                 //if (value is IStructBox box) return FromClass(box);


### PR DESCRIPTION
@jakubmisek ,  here is a patch for [issue 1103](https://github.com/peachpiecompiler/peachpie/issues/1103), it upscales the `sbyte` and `short` to integer in PhpValue FromClr function, which can fix the problem that PDO not able to handle TinyInt and SmallInt fields.   Could you please take a look and merge it? 

<img width="275" alt="Screenshot 2023-02-09 103312" src="https://user-images.githubusercontent.com/17474871/217703015-570d6ac5-754a-442e-aafe-b9309a23fd3c.png">
