### PR TITLE
PHP 8.3 features, Updated PHP parser

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,7 +42,7 @@
     
     <PeachpieLibraryRegularExpressionsVersion>1.7.0</PeachpieLibraryRegularExpressionsVersion>
     <MySqlConnectorVersion>2.0.0</MySqlConnectorVersion>
-    <ParserVersion>8.4.16490</ParserVersion>
+    <ParserVersion>8.4.16509</ParserVersion>
     <PeachpieMicrosoftCodeAnalysisVersion>3.7.1</PeachpieMicrosoftCodeAnalysisVersion>
     
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,7 +42,7 @@
     
     <PeachpieLibraryRegularExpressionsVersion>1.7.0</PeachpieLibraryRegularExpressionsVersion>
     <MySqlConnectorVersion>2.0.0</MySqlConnectorVersion>
-    <ParserVersion>8.2.13161</ParserVersion>
+    <ParserVersion>8.4.16490</ParserVersion>
     <PeachpieMicrosoftCodeAnalysisVersion>3.7.1</PeachpieMicrosoftCodeAnalysisVersion>
     
   </PropertyGroup>

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundExpression.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundExpression.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Text;
 using System.Threading.Tasks;
+using Devsense.PHP.Text;
 
 namespace Pchp.CodeAnalysis.Semantics
 {
@@ -3480,9 +3481,8 @@ namespace Pchp.CodeAnalysis.Semantics
 
             // get location of evaluated code
             var filepath = cg.ContainingFile.RelativeFilePath;
-            int line, col;
             var unit = this.PhpSyntax.ContainingSourceUnit;
-            unit.GetLineColumnFromPosition(this.CodeExpression.PhpSyntax.Span.Start, out line, out col);
+            unit.GetLineColumnFromPosition(this.CodeExpression.PhpSyntax.Span.Start, out var line, out var col);
 
             // Template: Operators.Eval(ctx, locals, @this, self, code, currentpath, line, column)
             cg.EmitLoadContext();

--- a/src/Peachpie.CodeAnalysis/CommandLine/PhpCommandLineParser.cs
+++ b/src/Peachpie.CodeAnalysis/CommandLine/PhpCommandLineParser.cs
@@ -1076,7 +1076,7 @@ namespace Pchp.CodeAnalysis.CommandLine
 
                     p = new AST.ActualParam(
                         Devsense.PHP.Text.Span.Invalid,
-                        new AST.StringLiteral(Devsense.PHP.Text.Span.Invalid, str.ToString())
+                        AST.StringLiteral.Create(Devsense.PHP.Text.Span.Invalid, str.ToString())
                     );
                     return true;
                 }
@@ -1113,7 +1113,7 @@ namespace Pchp.CodeAnalysis.CommandLine
             attr = new AST.AttributeElement(
                 span,
                 new AST.ClassTypeRef(span, QualifiedName.Parse(fqn.Trim().ToString().Replace('.', QualifiedName.Separator), true)),
-                new AST.CallSignature(signature, span)
+                new AST.CallSignature(signature.ToArray(), span)
             );
             return true;
         }

--- a/src/Peachpie.CodeAnalysis/DocumentationComments/DocumentationCommentCompiler.cs
+++ b/src/Peachpie.CodeAnalysis/DocumentationComments/DocumentationCommentCompiler.cs
@@ -186,7 +186,7 @@ namespace Pchp.CodeAnalysis.DocumentationComments
             //var ps = routine.Parameters;
 
             // PHPDoc
-            WriteSummary(output, phpdoc.Summary);
+            WriteSummary(output, phpdoc.SummaryOrDefault());
 
             for (var entry = phpdoc.Entries; entry != null; entry = entry.Next)
             {
@@ -262,7 +262,7 @@ namespace Pchp.CodeAnalysis.DocumentationComments
             var phpdoc = type.Syntax?.PHPDoc;
             if (phpdoc != null)
             {
-                WriteSummary(_writer, phpdoc.Summary);
+                WriteSummary(_writer, phpdoc.SummaryOrDefault());
             }
             _writer.WriteLine("</member>");
 
@@ -272,9 +272,8 @@ namespace Pchp.CodeAnalysis.DocumentationComments
 
             foreach (var field in type.GetMembers().OfType<SourceFieldSymbol>())
             {
-                if ((phpdoc = field.PHPDocBlock) != null)
+                if (field.PHPDocBlock?.HasSummary(out var summary) == true)
                 {
-                    var summary = phpdoc.Summary;
                     var value = string.Empty;
                     if (string.IsNullOrEmpty(summary))
                     {
@@ -289,7 +288,7 @@ namespace Pchp.CodeAnalysis.DocumentationComments
 
                             if (!string.IsNullOrEmpty(typename))
                             {
-                                value = string.Format("<value>{0}</value>", XmlEncode(typename));
+                                value = $"<value>{XmlEncode(typename)}</value>";
                             }
                         }
                     }

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/ExpressionAnalysis.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/ExpressionAnalysis.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Devsense.PHP.Text;
 using Ast = Devsense.PHP.Syntax.Ast;
 
 namespace Pchp.CodeAnalysis.FlowAnalysis

--- a/src/Peachpie.CodeAnalysis/Semantics/Graph/BuilderVisitor.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Graph/BuilderVisitor.cs
@@ -836,7 +836,7 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
 
         public override void VisitLabelStmt(LabelStmt x)
         {
-            var/*!*/label = GetLabelBlock(x.Name.Name.Value);
+            var/*!*/label = GetLabelBlock(x.Label);
             if ((label.Flags & ControlFlowGraph.LabelBlockFlags.Defined) != 0)
             {
                 label.Flags |= ControlFlowGraph.LabelBlockFlags.Redefined;  // label was defined already
@@ -844,7 +844,7 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
             }
 
             label.Flags |= ControlFlowGraph.LabelBlockFlags.Defined;        // label is defined
-            label.LabelSpan = x.Name.Span;
+            label.LabelSpan = x.LabelSpan;
 
             _current = WithNewOrdinal(Connect(_current, label.TargetBlock));
         }

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFieldSymbol.cs
@@ -71,6 +71,12 @@ namespace Pchp.CodeAnalysis.Symbols
 
         readonly BoundExpression _initializer;
 
+        /// <summary>
+        /// Optional. Typed constant or typed field.
+        /// In case of field, we must asusme the value can be referenced (wrapped into PhpAlias).
+        /// </summary>
+        readonly TypeRef _typeRef;
+
         ImmutableArray<AttributeData> _attributes;
 
         /// <summary>
@@ -164,7 +170,8 @@ namespace Pchp.CodeAnalysis.Symbols
             SourceTypeSymbol type, string name, Location location, Accessibility accessibility,
             IDocBlock phpdoc, PhpPropertyKind kind,
             BoundExpression initializer = null,
-            ImmutableArray<AttributeData> attributes = default)
+            ImmutableArray<AttributeData> attributes = default,
+            TypeRef typeRef = null)
         {
             Contract.ThrowIfNull(type);
             Contract.ThrowIfNull(name);
@@ -176,6 +183,7 @@ namespace Pchp.CodeAnalysis.Symbols
             _initializer = initializer;
             _location = location;
             _attributes = attributes.IsDefault ? ImmutableArray<AttributeData>.Empty : attributes;
+            _typeRef = typeRef;
             PHPDocBlock = phpdoc;
 
             // implicit attributes from PHPDoc
@@ -235,6 +243,12 @@ namespace Pchp.CodeAnalysis.Symbols
             //
             if ((IsConst || IsReadOnly) && Initializer != null)
             {
+                if (_typeRef != null)
+                {
+                    // PHP 8.3 typed class constant
+                    return DeclaringCompilation.GetTypeFromTypeRef(_typeRef, _containingType);
+                }
+                
                 // resolved type symbol if possible
                 if (Initializer.ResultType != null)
                 {

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceFieldSymbol.cs
@@ -282,12 +282,8 @@ namespace Pchp.CodeAnalysis.Symbols
 
         public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var summary = string.Empty;
-
-            if (PHPDocBlock != null)
+            if (PHPDocBlock?.HasSummary(out var summary) == true)
             {
-                summary = PHPDocBlock.Summary;
-
                 if (string.IsNullOrWhiteSpace(summary))
                 {
                     // try @var or @staticvar:
@@ -297,9 +293,11 @@ namespace Pchp.CodeAnalysis.Symbols
                         summary = vartag.ToString();
                     }
                 }
+
+                return summary;
             }
 
-            return summary;
+            return string.Empty;
         }
     }
 }

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceLambdaSymbol.cs
@@ -127,7 +127,7 @@ namespace Pchp.CodeAnalysis.Symbols
         {
             _body = ImmutableArray.Create<Statement>(new JumpStmt(syntax.Expression.Span, JumpStmt.Types.Return, syntax.Expression));
             _useparams = EnumerateCapturedVariables(syntax)
-                .Select(v => new FormalParam(Span.Invalid, v.Value, Span.Invalid, null, FormalParam.Flags.Default, null))
+                .Select(v => new FormalParam(Span.Invalid, new VariableName(v.Value)))
                 .ToArray();
         }
 

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceTypeSymbol.cs
@@ -1132,7 +1132,9 @@ namespace Pchp.CodeAnalysis.Symbols
                         flist.Modifiers.GetAccessibility(), flist.PHPDoc,
                         fkind,
                         initializer: (f.Initializer != null) ? binder.BindWholeExpression(f.Initializer, BoundAccess.Read).SingleBoundElement() : null,
-                        attributes: binder.BindAttributes(flist.GetAttributes()));
+                        attributes: binder.BindAttributes(flist.GetAttributes()),
+                        typeRef: flist.Type // CONSIDER: readonly non-aliased fields only?
+                    );
                 }
             }
 
@@ -1146,7 +1148,9 @@ namespace Pchp.CodeAnalysis.Symbols
                         clist.Modifiers.GetAccessibility(), clist.PHPDoc,
                         PhpPropertyKind.ClassConstant,
                         initializer: binder.BindWholeExpression(c.Initializer, BoundAccess.Read).SingleBoundElement(),
-                        attributes: binder.BindAttributes(clist.GetAttributes()));
+                        attributes: binder.BindAttributes(clist.GetAttributes()),
+                        typeRef: clist.Type
+                    );
                 }
             }
         }

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceTypeSymbol.cs
@@ -1141,8 +1141,8 @@ namespace Pchp.CodeAnalysis.Symbols
             {
                 foreach (var c in clist.Constants)
                 {
-                    yield return new SourceFieldSymbol(this, c.Name.Name.Value,
-                        CreateLocation(c.Name.Span),
+                    yield return new SourceFieldSymbol(this, c.Name.Value,
+                        CreateLocation(c.NameSpan),
                         clist.Modifiers.GetAccessibility(), clist.PHPDoc,
                         PhpPropertyKind.ClassConstant,
                         initializer: binder.BindWholeExpression(c.Initializer, BoundAccess.Read).SingleBoundElement(),
@@ -1755,7 +1755,7 @@ namespace Pchp.CodeAnalysis.Symbols
 
         public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Syntax.PHPDoc?.Summary ?? string.Empty;
+            return Syntax.PHPDoc?.SummaryOrDefault() ?? string.Empty;
         }
     }
 

--- a/src/Peachpie.CodeAnalysis/Syntax/NodesFactory.cs
+++ b/src/Peachpie.CodeAnalysis/Syntax/NodesFactory.cs
@@ -134,26 +134,27 @@ namespace Peachpie.CodeAnalysis.Syntax
             return Root = (GlobalCode)base.GlobalCode(span, statements, context);
         }
 
-        public override LangElement Function(Span span, bool conditional, bool aliasReturn, PhpMemberAttributes attributes, TypeRef returnType, Name name, Span nameSpan, IEnumerable<FormalTypeParam> typeParamsOpt, IEnumerable<FormalParam> formalParams, Span formalParamsSpan, LangElement body)
+        public override LangElement Function(Span span, bool conditional, bool aliasReturn, PhpMemberAttributes attributes, TypeRef returnType, Name name, Span nameSpan, FormalTypeParam[] typeParamsOpt, FormalParam[] formalParams, Span formalParamsSpan, LangElement body)
         {
             return AddAndReturn(
                 ref _functions,
-                (FunctionDecl)base.Function(span, conditional, aliasReturn, attributes, returnType, name, nameSpan, typeParamsOpt, formalParams, formalParamsSpan, body));
+                (FunctionDecl)base.Function(span, conditional, aliasReturn, attributes, returnType, name, nameSpan, typeParamsOpt, formalParams, formalParamsSpan, body)
+            );
         }
 
-        public override LangElement Type(Span span, Span headingSpan, bool conditional, PhpMemberAttributes attributes, Name name, Span nameSpan, IEnumerable<FormalTypeParam> typeParamsOpt, INamedTypeRef baseClassOpt, IEnumerable<INamedTypeRef> implements, IEnumerable<LangElement> members, Span bodySpan)
+        public override LangElement Type(Span span, Span headingSpan, bool conditional, PhpMemberAttributes attributes, Name name, Span nameSpan, IEnumerable<FormalTypeParam> typeParamsOpt, INamedTypeRef baseClassOpt, INamedTypeRef[] implements, IEnumerable<LangElement> members, Span bodySpan)
         {
             var tref = (TypeDecl)base.Type(span, headingSpan, conditional, attributes, name, nameSpan, typeParamsOpt, baseClassOpt, implements, members, bodySpan);
 
             return AddAndReturn(ref _types, tref);
         }
 
-        public override LangElement DeclList(Span span, PhpMemberAttributes attributes, IList<LangElement> decls, TypeRef type)
+        public override LangElement DeclList(Span span, PhpMemberAttributes attributes, IReadOnlyList<LangElement> decls, TypeRef type)
         {
             return base.DeclList(span, attributes, decls, type);
         }
 
-        public override LangElement Method(Span span, bool aliasReturn, PhpMemberAttributes attributes, TypeRef returnType, Span returnTypeSpan, string name, Span nameSpan, IEnumerable<FormalTypeParam> typeParamsOpt, IEnumerable<FormalParam> formalParams, Span formalParamsSpan, IEnumerable<ActualParam> baseCtorParams, LangElement body)
+        public override LangElement Method(Span span, bool aliasReturn, PhpMemberAttributes attributes, TypeRef returnType, Span returnTypeSpan, string name, Span nameSpan, FormalTypeParam[] typeParamsOpt, FormalParam[] formalParams, Span formalParamsSpan, ActualParam[] baseCtorParams, LangElement body)
         {
             return base.Method(span, aliasReturn, attributes, returnType, returnTypeSpan, name, nameSpan, typeParamsOpt, formalParams, formalParamsSpan, baseCtorParams, body);
         }
@@ -167,16 +168,16 @@ namespace Peachpie.CodeAnalysis.Syntax
             return tref;
         }
 
-        public override LangElement Lambda(Span span, Span headingSpan, bool aliasReturn, TypeRef returnType, IEnumerable<FormalParam> formalParams, Span formalParamsSpan, IEnumerable<FormalParam> lexicalVars, LangElement body)
+        public override LangElement Lambda(Span span, Span headingSpan, bool aliasReturn, TypeRef returnType, FormalParam[] @params, Span formalParamsSpan, FormalParam[] formalParams, LangElement body)
         {
             return AddAndReturn(ref _lambdas,
-                (LambdaFunctionExpr)base.Lambda(span, headingSpan, aliasReturn, returnType, formalParams, formalParamsSpan, lexicalVars, body));
+                (LambdaFunctionExpr)base.Lambda(span, headingSpan, aliasReturn, returnType, formalParams, formalParamsSpan, formalParams, body));
         }
 
-        public override LangElement ArrowFunc(Span span, Span headingSpan, bool aliasReturn, TypeRef returnType, IEnumerable<FormalParam> formalParams, Span formalParamsSpan, LangElement expression)
+        public override LangElement ArrowFunc(Span span, Span headingSpan, bool aliasReturn, TypeRef returnType, FormalParam[] @params, Span formalParamsSpan, LangElement expression)
         {
             return AddAndReturn(ref _lambdas,
-                (ArrowFunctionExpr)base.ArrowFunc(span, headingSpan, aliasReturn, returnType, formalParams, formalParamsSpan, expression));
+                (ArrowFunctionExpr)base.ArrowFunc(span, headingSpan, aliasReturn, returnType, @params, formalParamsSpan, expression));
         }
 
         public override LangElement Yield(Span span, LangElement keyOpt, LangElement valueOpt)

--- a/src/Peachpie.CodeAnalysis/Syntax/NodesFactory.cs
+++ b/src/Peachpie.CodeAnalysis/Syntax/NodesFactory.cs
@@ -168,16 +168,25 @@ namespace Peachpie.CodeAnalysis.Syntax
             return tref;
         }
 
-        public override LangElement Lambda(Span span, Span headingSpan, bool aliasReturn, TypeRef returnType, FormalParam[] @params, Span formalParamsSpan, FormalParam[] formalParams, LangElement body)
+        public override LangElement Lambda(
+            Span span,
+            Span headingSpan,
+            bool aliasReturn,
+            TypeRef returnType,
+            FormalParam[] formalParams,
+            Span formalParamsSpan,
+            FormalParam[] lexicalVars,
+            LangElement body)
         {
             return AddAndReturn(ref _lambdas,
-                (LambdaFunctionExpr)base.Lambda(span, headingSpan, aliasReturn, returnType, formalParams, formalParamsSpan, formalParams, body));
+                (LambdaFunctionExpr)base.Lambda(span, headingSpan, aliasReturn, returnType, formalParams, formalParamsSpan, lexicalVars, body)
+            );
         }
 
-        public override LangElement ArrowFunc(Span span, Span headingSpan, bool aliasReturn, TypeRef returnType, FormalParam[] @params, Span formalParamsSpan, LangElement expression)
+        public override LangElement ArrowFunc(Span span, Span headingSpan, bool aliasReturn, TypeRef returnType, FormalParam[] @params, Span paramsSpan, LangElement expression)
         {
             return AddAndReturn(ref _lambdas,
-                (ArrowFunctionExpr)base.ArrowFunc(span, headingSpan, aliasReturn, returnType, @params, formalParamsSpan, expression));
+                (ArrowFunctionExpr)base.ArrowFunc(span, headingSpan, aliasReturn, returnType, @params, paramsSpan, expression));
         }
 
         public override LangElement Yield(Span span, LangElement keyOpt, LangElement valueOpt)

--- a/src/Peachpie.CodeAnalysis/Syntax/PhpSourceUnit.cs
+++ b/src/Peachpie.CodeAnalysis/Syntax/PhpSourceUnit.cs
@@ -12,7 +12,12 @@ using Pchp.CodeAnalysis;
 
 namespace Peachpie.CodeAnalysis.Syntax
 {
-    sealed class PhpSourceUnit : SourceUnit
+    interface IPhpSourceUnit
+    {
+        ReadOnlySpan<char> GetSourceCode(Span span);
+    }
+    
+    sealed class PhpSourceUnit : SourceUnit, IPhpSourceUnit
     {
         public SourceText SourceText { get; set; }
 
@@ -27,9 +32,9 @@ namespace Peachpie.CodeAnalysis.Syntax
             // TODO: dispose SourceText ?
         }
 
-        public override string GetSourceCode(Span span)
+        public ReadOnlySpan<char> GetSourceCode(Span span)
         {
-            return SourceText.ToString(span.ToTextSpan());
+            return SourceText.ToString(span.ToTextSpan()).AsSpan();
         }
 
         public void Parse(NodesFactory factory, IErrorSink<Span> errors,
@@ -48,7 +53,7 @@ namespace Peachpie.CodeAnalysis.Syntax
                     factory,
                     parser.CreateTypeRef))
                 {
-                    ast = parser.Parse(provider, factory, features, errors, recovery);
+                    this.Ast = (GlobalCode)parser.Parse(provider, factory, features, errors, recovery);
                 }
             }
         }

--- a/src/Peachpie.CodeAnalysis/Syntax/PhpSyntaxTree.cs
+++ b/src/Peachpie.CodeAnalysis/Syntax/PhpSyntaxTree.cs
@@ -86,11 +86,13 @@ namespace Pchp.CodeAnalysis
             { new Version(8, 0), LanguageFeatures.Php80Set },
             { new Version(8, 1), LanguageFeatures.Php81Set },
             { new Version(8, 2), LanguageFeatures.Php82Set },
+            { new Version(8, 3), LanguageFeatures.Php83Set },
+            { new Version(8, 4), LanguageFeatures.Php84Set },
         };
 
         public static Version LatestLanguageVersion => SupportedLanguageVersions.Max();
 
-        public static Version DefaultLanguageVersion => new Version(8, 2);
+        public static Version DefaultLanguageVersion => new Version(8, 4);
 
         public static IReadOnlyCollection<Version> SupportedLanguageVersions => s_langversions.Keys;
 

--- a/src/Peachpie.CodeAnalysis/Utilities/ExceptionUtilities.cs
+++ b/src/Peachpie.CodeAnalysis/Utilities/ExceptionUtilities.cs
@@ -9,6 +9,7 @@ using Pchp.CodeAnalysis.Semantics;
 using Microsoft.CodeAnalysis.CodeGen;
 using Pchp.CodeAnalysis.Symbols;
 using System.Diagnostics;
+using Devsense.PHP.Text;
 
 namespace Peachpie.CodeAnalysis.Utilities
 {
@@ -27,14 +28,14 @@ namespace Peachpie.CodeAnalysis.Utilities
             {
                 // get location from AST
                 var unit = syntax.ContainingSourceUnit;
-                unit.GetLineColumnFromPosition(syntax.Span.Start, out int line, out int col);
+                unit.GetLineColumnFromPosition(syntax.Span.Start, out var line, out var col);
                 return $"{unit.FilePath}({line + 1}, {col + 1})";
             }
             else if (il.SeqPointsOpt != null && il.SeqPointsOpt.Count != 0)
             {
                 // get location from last sequence point
                 var pt = il.SeqPointsOpt.Last();
-                ((PhpSyntaxTree)pt.SyntaxTree).Source.GetLineColumnFromPosition(pt.Span.Start, out int line, out int col);
+                ((PhpSyntaxTree)pt.SyntaxTree).Source.GetLineColumnFromPosition(pt.Span.Start, out var line, out var col);
                 return $"{pt.SyntaxTree.FilePath}({line + 1}, {col + 1})";
             }
             else if (routine != null)

--- a/tests/constructs/class_consts_002.php
+++ b/tests/constructs/class_consts_002.php
@@ -1,0 +1,13 @@
+<?php
+namespace constructs\class_consts_002;
+
+class Test
+{
+    const string C = 'hello';
+}
+
+$name = "C";
+
+echo Test::C, PHP_EOL;
+echo Test::{$name}, PHP_EOL;
+echo 'Done.';


### PR DESCRIPTION
- updated parser implementation with PHP 8.4 syntax (not fully compilable), optimizations, and fixes
- dynamic class constants `FOO::{$bar}`
- typed class constants `const int N = 123;`